### PR TITLE
[Feat] 테스트 커버리지 체크를 위한 jacoco 라이브러리 적용

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.2
+        uses: madrapps/jacoco-report@v1.7.2
         with:
           title: 📝 Test Coverage Report
           paths: ${{ github.workspace }}/backend/build/jacoco/index.xml

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -38,15 +38,18 @@ jobs:
           echo "----- /backend -----"
           ls -al .
 
-#      - name: Test with Gradle
-#        run: backend/gradlew clean jacocoTestReport
+      - name: Test with Gradle
+        working-directory: backend
+        run: ./gradlew clean test
 
-#    - name: Add coverage to PR
-#        id: jacoco
-#        uses: madrapps/jacoco-report@v1.2
-#        with:
-#          paths: ${{ github.workspace }}/build/jacoco/index.xml
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          title: "테스트 커버리지 측정"
-#          min-coverage-overall: 40
-#          min-coverage-changed-files: 40
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: 📝 Test Coverage Report
+          paths: ${{ github.workspace }}/backend/build/jacoco/index.xml
+          token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
+          min-coverage-overall: 20
+          min-coverage-changed-files: 20
+          update-comment: true
+          continue-on-error: true

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.4'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.imsnacks'
@@ -39,3 +40,42 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+}
+
+jacoco {
+	toolVersion = "0.8.13"
+	reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+}
+
+jacocoTestReport {
+	reports {
+		xml.required = false
+		csv.required = false
+		html.outputLocation = layout.buildDirectory.dir('jacoco/index.html')
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			element = 'CLASS'
+			includes = ['com.imsnacks.*']
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				maximum = 0.8
+			}
+		}
+	}
+}
+
+check.dependsOn jacocoTestCoverageVerification


### PR DESCRIPTION
## 📌 연관된 이슈

- close #68 

---

## 📝작업 내용

1. 테스트 커버리지 체크를 위한 jacoco 라이브러리 의존성을 추가했습니다.
- `./gradlew test` 또는 `./gradlew jacocoTestReport` 커맨드를 실행하면 `build/jacoco/index.html` 로 결과 파일이 생성됩니다.
- 브랜치 커버리지를 최소 80% 달성하는 것으로 룰을 세팅했습니다. (➡️ 현재는 코드에 브랜치가 없기 때문에 통과함)
- 💡 현재는 모든 클래스를  커버리지 체크 대상으로 뒀습니다. 추후에 엔티티 클래스 등 커버리지 체크 대상을 특정해야 합니다. 

2. CI 워크플로우에 커버리지 결과를 PR 코멘트로 남기는 스텝을 추가했습니다.
- 개발 초반에는 아래와 같이 최소 커버리지 조건을 20으로 작게 설정하고 조건 실패에도 continue 하도록 세팅했습니다.
- 본격적인 비즈니스 로직 구현에 들어가면 커버리지 조건을 강화할 예정입니다.
```
min-coverage-overall: 20
min-coverage-changed-files: 20
update-comment: true
continue-on-error: true
```
- PR 이 업데이트되면 새로운 커버리지 결과 코멘트가 달리는 것이 아니라 기존 코멘트가 업데이트 됩니다. 
---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)