### PR TITLE
[Feat] PR 생성 시 status 변경 자동화

### DIFF
--- a/.github/workflows/auto-issue-column-transition.yml
+++ b/.github/workflows/auto-issue-column-transition.yml
@@ -5,42 +5,113 @@ on:
     types: [opened, ready_for_review]
 
 jobs:
-  update-project:
+  move-issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Move linked issue to "Under Review"
+      - name: Move linked issue to Under Review column in ProjectV2
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
           script: |
-            const prBody = context.payload.pull_request.body;
-            const issueRegex = /(?:close|Fixes|Resolves) #(\d+)/gi;
-            let match;
-            while ((match = issueRegex.exec(prBody)) !== null) {
-              const issueNumber = match[1];
-              const issue = await github.rest.issues.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber
-              });
+            const issueRegex = /(?:close|closes|fixes|resolves)\s+#(\d+)/gi;
+            const prBody = context.payload.pull_request.body || "";
+            const matches = [...prBody.matchAll(issueRegex)];
+            if (matches.length === 0) return;
 
-              const projects = await github.rest.projects.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo
-              });
+            const issueNumber = parseInt(matches[0][1]);
 
-              const projectId = projects.data.find(p => p.name === "ImSnacks's project")?.id;
-              if (!projectId) return;
+            const projectNumber = 15;
+            const organization = context.repo.owner;
 
-              const cards = await github.rest.projects.listCards({
-                column_id: ${{ secrets.UNDER_REVIEW_COLUMN_ID }},
-                per_page: 100
-              });
+            // GraphQL 클라이언트 호출
+            const result = await github.graphql(`
+              query($org: String!, $projNum: Int!, $issueNumber: Int!, $repo: String!) {
+                organization(login: $org) {
+                  projectV2(number: $projNum) {
+                    id
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                repository(owner: $org, name: $repo) {
+                  issue(number: $issueNumber) {
+                    id
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project {
+                          number
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `, {
+              org: organization,
+              projNum: projectNumber,
+              issueNumber: issueNumber,
+              repo: context.repo.repo
+            });
 
-              // 이슈를 Under Review로 이동
-              await github.rest.projects.moveCard({
-                card_id: issue.data.id,
-                column_id: ${{ secrets.UNDER_REVIEW_COLUMN_ID }} ,
-                position: 'top'
-              });
+            const projectId = result.organization.projectV2.id;
+            const issueId = result.repository.issue.id;
+
+            const item = result.repository.issue.projectItems.nodes.find(
+              (node) => node.project.number === projectNumber
+            );
+            const itemId = item?.id;
+
+            const field = result.organization.projectV2.fields.nodes.find(
+              (field) => field.name === "Status"
+            );
+
+            if (!field) {
+              core.setFailed("Status 필드를 찾을 수 없습니다.");
+              return;
             }
+
+            const underReviewOption = field.options.find(
+              (opt) => opt.name.toLowerCase() === "under review"
+            );
+
+            if (!underReviewOption) {
+              core.setFailed('"Under Review" 옵션을 찾을 수 없습니다.');
+              return;
+            }
+
+            await github.graphql(`
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: {
+                      singleSelectOptionId: $optionId
+                    }
+                  }
+                ) {
+                  projectV2Item {
+                    id
+                  }
+                }
+              }
+            `, {
+              projectId: projectId,
+              itemId: itemId,
+              fieldId: field.id,
+              optionId: underReviewOption.id
+            });
+
+            console.log(`이슈 #${issueNumber}의 Status를 "Under Review"로 변경했습니다.`);

--- a/.github/workflows/auto-issue-column-transition.yml
+++ b/.github/workflows/auto-issue-column-transition.yml
@@ -1,0 +1,46 @@
+name: Move issue to "Under Review" on PR creation
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  update-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move linked issue to "Under Review"
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
+          script: |
+            const prBody = context.payload.pull_request.body;
+            const issueRegex = /(?:close|Fixes|Resolves) #(\d+)/gi;
+            let match;
+            while ((match = issueRegex.exec(prBody)) !== null) {
+              const issueNumber = match[1];
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber
+              });
+
+              const projects = await github.rest.projects.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+
+              const projectId = projects.data.find(p => p.name === "ImSnacks's project")?.id;
+              if (!projectId) return;
+
+              const cards = await github.rest.projects.listCards({
+                column_id: ${{ secrets.UNDER_REVIEW_COLUMN_ID }},
+                per_page: 100
+              });
+
+              // 이슈를 Under Review로 이동
+              await github.rest.projects.moveCard({
+                card_id: issue.data.id,
+                column_id: ${{ secrets.UNDER_REVIEW_COLUMN_ID }} ,
+                position: 'top'
+              });
+            }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #71

---

## 📝작업 내용

- `PR 생성` 또는 `존재하는 PR이 draft에서 ready for review 상태로 이동하는 경우` 에 PR에 연결된 이슈가 프로젝트에서 **Under Review** status로 이동하는 자동화를 구현했습니다.
- 디폴트 워크플로우는 리뷰어가  **“Changes requested” 상태로 리뷰를 남겼을 때** **Under Review** status로 이동하기 때문에 적절하지 않다고 생각했습니다. [워크플로우 참고](https://github.com/orgs/softeerbootcamp-6th/projects/15/workflows/53388735)
- 테스트 완료했습니다. 


---

## 💬리뷰 요구사항

프로젝트에 PR 자체를 추가하는 방법도 있는데요! 현재는 그냥 이슈를 옮기는 방식으로 구현을 했습니다. 이렇게 진행하는 것이 괜찮으신지 의견 부탁드립니다 ~ 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)