### PR TITLE
[Fix] WeatherRisk 불필요한 setter 삭제

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/writer/WeatherWriter.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/writer/WeatherWriter.java
@@ -24,14 +24,11 @@ public class WeatherWriter implements ItemWriter<ShortTermWeatherDto> {
         List<WeatherRisk> weatherRisks = new ArrayList<>();
 
         List<? extends ShortTermWeatherDto> items = chunk.getItems();
-        int nx = items.get(0).getNx();
-        int ny = items.get(0).getNy();
-
         items.forEach(item -> {
             item.getWeatherForecastByTimeList().forEach(weatherForecastByTime -> {
                 forecasts.add(ShortTermWeatherForecast.builder()
-                        .nx(nx)
-                        .ny(ny)
+                        .nx(item.getNx())
+                        .ny(item.getNy())
                         .fcstTime(weatherForecastByTime.getFcstTime())
                         .precipitation(weatherForecastByTime.getPrecipitation())
                         .temperature(weatherForecastByTime.getTemperature())


### PR DESCRIPTION
## 📌 연관된 이슈

- close #78

---

## 📝작업 내용

`ItemWriter` 구현에서 Chunk 내의 `ShortTermWeatherDto` 아이템들의 nx, ny를 모두 통일해버린 오류를 수정했습니다.

---

## 💬리뷰 요구사항

x

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)