### PR TITLE
 [Feat] Batch 서버 현재 시간으로 JobParameters 생성

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
@@ -1,0 +1,34 @@
+package com.ImSnacks.NyeoreumnagiBatch.utils.params;
+
+import com.ImSnacks.NyeoreumnagiBatch.reader.ApiRequestValues;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+public class WeatherJobParams {
+    private static final List<Integer> BASE_TIMES = Arrays.asList(2, 5, 8, 11, 14, 17, 20, 23);
+
+    public static JobParameters get() {
+        String baseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String baseTime = String.format("%02d", getBaseTime());
+        return new JobParametersBuilder()
+                .addString(ApiRequestValues.BASE_DATE.toString(), baseDate)
+                .addString(ApiRequestValues.BASE_TIME.toString(), baseTime)
+                .toJobParameters();
+    }
+
+    private static int getBaseTime() {
+        int nowHour = LocalTime.now().getHour();
+        for (int t : BASE_TIMES) {
+            if (t <= nowHour) {
+                return t;
+            }
+        }
+        return BASE_TIMES.get(BASE_TIMES.size() - 1);
+    }
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
@@ -14,21 +14,30 @@ public class WeatherJobParams {
     private static final List<Integer> BASE_TIMES = Arrays.asList(2, 5, 8, 11, 14, 17, 20, 23);
 
     public static JobParameters get() {
-        String baseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        String baseTime = String.format("%02d00", getBaseTime());
+        LocalDate nowDate = LocalDate.now();
+        int nowHour = LocalTime.now().getHour();
+        if (nowHour < 2) { // 00시, 01시의 경우, 전날 23시를 base로 한다.
+            nowHour = 23;
+            nowDate = nowDate.minusDays(1);
+        }
+
+        String baseDate = nowDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String baseTime = String.format("%02d00", getBaseTime(nowHour));
         return new JobParametersBuilder()
                 .addString(ApiRequestValues.BASE_DATE.toString(), baseDate)
                 .addString(ApiRequestValues.BASE_TIME.toString(), baseTime)
                 .toJobParameters();
     }
 
-    private static int getBaseTime() {
-        int nowHour = LocalTime.now().getHour();
-        for (int t : BASE_TIMES) {
+    private static int getBaseTime(int nowHour) {
+        assert (nowHour >= 2);
+        for (int i = BASE_TIMES.size() - 1; i >= 0; --i) {
+            int t = BASE_TIMES.get(i);
             if (t <= nowHour) {
                 return t;
             }
         }
-        return BASE_TIMES.get(BASE_TIMES.size() - 1);
+        assert (false);
+        return 0;
     }
 }

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
@@ -16,7 +16,7 @@ public class WeatherJobParams {
     public static JobParameters get() {
         String baseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
         String baseTime = String.format("%02d00", getBaseTime());
-        return new JobParametersBuilder.
+        return new JobParametersBuilder()
                 .addString(ApiRequestValues.BASE_DATE.toString(), baseDate)
                 .addString(ApiRequestValues.BASE_TIME.toString(), baseTime)
                 .toJobParameters();

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/utils/params/WeatherJobParams.java
@@ -15,8 +15,8 @@ public class WeatherJobParams {
 
     public static JobParameters get() {
         String baseDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        String baseTime = String.format("%02d", getBaseTime());
-        return new JobParametersBuilder()
+        String baseTime = String.format("%02d00", getBaseTime());
+        return new JobParametersBuilder.
                 .addString(ApiRequestValues.BASE_DATE.toString(), baseDate)
                 .addString(ApiRequestValues.BASE_TIME.toString(), baseTime)
                 .toJobParameters();

--- a/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/ApiCallerTest.java
+++ b/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/ApiCallerTest.java
@@ -1,56 +1,12 @@
 package com.ImSnacks.NyeoreumnagiBatch;
 
-import com.ImSnacks.NyeoreumnagiBatch.reader.ApiCaller;
-import com.ImSnacks.NyeoreumnagiBatch.reader.ApiRequestValues;
-
-import com.ImSnacks.NyeoreumnagiBatch.reader.dto.VilageFcstResponseDto;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @Transactional
 @Rollback
 public class ApiCallerTest {
 
-    private static final Logger log = LoggerFactory.getLogger(ApiCallerTest.class);
-
-    @Test
-    void shouldReturnExpectedUrl() {
-        // given
-        String baseDate = "20250804";
-        String baseTime = "0500";
-        int nx = 61;
-        int ny = 128;
-
-        // when
-        String actual = ApiCaller.buildUriString(baseDate, baseTime, nx, ny);
-
-        log.debug(actual);
-
-        // then
-        // API authKey는 제외
-        //String expected = String.format("%s?authKey&numOfRows=1000&pageNo=1&dataType=JSON&base_date=%s&base_time=%s&nx=%d&ny=%d", ApiRequestValues.URI.toString(), baseDate, baseTime, nx, ny);
-        //assertEquals(expected, actual);
-    }
-
-    @Test
-    void shouldReturnExpectedDto() {
-        // given
-        String baseDate = "20250805";
-        String baseTime = "0500";
-        int nx = 61;
-        int ny = 128;
-
-        // when
-        VilageFcstResponseDto actual = ApiCaller.call(baseDate, baseTime, nx, ny);
-
-        // then
-        log.debug(actual.toString());
-    }
 }

--- a/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/ForecastTimeUtilsTest.java
+++ b/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/ForecastTimeUtilsTest.java
@@ -3,7 +3,8 @@ package com.ImSnacks.NyeoreumnagiBatch;
 import com.ImSnacks.NyeoreumnagiBatch.utils.ForecastTimeUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ForecastTimeUtilsTest {
 

--- a/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobParamsTest.java
+++ b/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobParamsTest.java
@@ -1,0 +1,13 @@
+package com.ImSnacks.NyeoreumnagiBatch;
+
+import com.ImSnacks.NyeoreumnagiBatch.utils.params.WeatherJobParams;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobParameters;
+
+public class WeatherJobParamsTest {
+    @Test
+    void 현재_기준_호출_시_JobParams_출력() {
+        JobParameters params = WeatherJobParams.get();
+        System.out.println(params.toString());
+    }
+}

--- a/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobParamsTest.java
+++ b/batch/src/test/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobParamsTest.java
@@ -8,6 +8,6 @@ public class WeatherJobParamsTest {
     @Test
     void 현재_기준_호출_시_JobParams_출력() {
         JobParameters params = WeatherJobParams.get();
-        System.out.println(params.toString());
+        //System.out.println(params.toString());
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #99 

---

## 📝작업 내용

 `public static JobParameters WeatherJobParams::get()`
- 기상청 api 호출 시에 필요한 시간 값을 JobParameters 형태로 반환합니다.
- `base_date`: 현재 날짜 (yyyyMMdd) / type: String
- `base_time`: 단기예보 API 예보 시각 중 현재 시각을 지나지 않은 가장 가까운 시각 (HH00) / type: String

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)