### PR TITLE
[Feat] 사용자 인증/인가를 위한 JWT 토큰 관련 기능 및 interceptor 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,7 +28,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/annotation/PreAuthorize.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/annotation/PreAuthorize.java
@@ -1,0 +1,11 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreAuthorize {
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/argumentResolver/JwtAuthHandlerArgumentResolver.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/argumentResolver/JwtAuthHandlerArgumentResolver.java
@@ -1,0 +1,26 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.argumentResolver;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.annotation.PreAuthorize;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class JwtAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasAnnotation = parameter.hasParameterAnnotation((PreAuthorize.class));
+        boolean hasType = long.class.isAssignableFrom(parameter.getParameterType());
+        return hasAnnotation && hasType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("memberId");
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/argumentResolver/JwtAuthHandlerArgumentResolver.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/argumentResolver/JwtAuthHandlerArgumentResolver.java
@@ -14,7 +14,7 @@ public class JwtAuthHandlerArgumentResolver implements HandlerMethodArgumentReso
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasAnnotation = parameter.hasParameterAnnotation((PreAuthorize.class));
-        boolean hasType = long.class.isAssignableFrom(parameter.getParameterType());
+        boolean hasType = Long.class.isAssignableFrom(parameter.getParameterType());
         return hasAnnotation && hasType;
     }
 

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/AuthResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/AuthResponseStatus.java
@@ -1,0 +1,25 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.exception;
+
+public enum AuthResponseStatus {
+    NO_MEMBERID(1001, "access token에 memberId가 없습니다."),
+    TOKEN_NOT_FOUND(1002, "access token이 없습니다."),
+    UNSUPPORTED_TOKEN_TYPE(1003, "지원하지 않는 token type입니다."),
+    EXPIRED_TOKEN(1004, "만료된 token입니다."),
+    ;
+
+    private int code;
+    private String message;
+
+    AuthResponseStatus(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/JwtException.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/JwtException.java
@@ -1,0 +1,15 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.exception;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.AuthResponseStatus;
+
+public class JwtException extends RuntimeException{
+    private AuthResponseStatus status;
+
+    public JwtException(AuthResponseStatus status) {
+        this.status = status;
+    }
+
+    public AuthResponseStatus getStatus() {
+        return status;
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/JwtException.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/exception/JwtException.java
@@ -1,7 +1,5 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.exception;
 
-import com.imsnacks.Nyeoreumnagi.common.auth.AuthResponseStatus;
-
 public class JwtException extends RuntimeException{
     private AuthResponseStatus status;
 

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/interceptor/JwtAuthInterceptor.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/interceptor/JwtAuthInterceptor.java
@@ -1,0 +1,67 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.interceptor;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.exception.JwtException;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static com.imsnacks.Nyeoreumnagi.common.auth.exception.AuthResponseStatus.*;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthInterceptor implements HandlerInterceptor {
+
+    private static final String JWT_TOKEN_PREFIX = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String method = request.getMethod();
+        String url = request.getRequestURI();
+        String accessToken = request.getHeader(HttpHeaders.COOKIE);
+
+        if(method.equals(HttpMethod.OPTIONS.name())){
+            return true;
+        }
+
+        accessToken = resolveAccessToken(accessToken);
+        validateAccessToken(accessToken);
+
+        Long memberId = jwtProvider.getMemberId(accessToken);
+        validatePayload(memberId);
+
+        request.setAttribute("memberId", memberId);
+        return true;
+    }
+
+    private String resolveAccessToken(String token) {
+        validateToken(token);
+        return token.substring(JWT_TOKEN_PREFIX.length());
+    }
+
+    private void validateToken(String token) {
+        if (token == null) {
+            throw new JwtException(TOKEN_NOT_FOUND);
+        }
+        if (!token.startsWith(JWT_TOKEN_PREFIX)) {
+            throw new JwtException(UNSUPPORTED_TOKEN_TYPE);
+        }
+    }
+
+    private void validateAccessToken(String accessToken) {
+        if (jwtProvider.isExpiredToken(accessToken)) {
+            throw new JwtException(EXPIRED_TOKEN);
+        }
+    }
+
+    private void validatePayload(Long memberId) {
+        if (memberId == null) {
+            throw new JwtException(NO_MEMBERID);
+        }
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
@@ -5,6 +5,7 @@ import lombok.*;
 import java.util.UUID;
 
 @Getter
+@AllArgsConstructor
 public class AuthTokens {
 
     private String accessToken;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
@@ -5,7 +5,6 @@ import lombok.*;
 import java.util.UUID;
 
 @Getter
-@Builder
 public class AuthTokens {
 
     private String accessToken;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
@@ -10,9 +10,8 @@ public class AuthTokens {
 
     private String accessToken;
     private UUID refreshToken;
-    private Long expiresIn;
 
-    public static AuthTokens of(String accessToken, UUID refreshToken, Long expiresIn) {
-        return new AuthTokens(accessToken, refreshToken, expiresIn);
+    public static AuthTokens of(String accessToken, UUID refreshToken) {
+        return new AuthTokens(accessToken, refreshToken);
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/AuthTokens.java
@@ -1,0 +1,18 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.jwt;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AuthTokens {
+
+    private String accessToken;
+    private UUID refreshToken;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, UUID refreshToken, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, expiresIn);
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.jwt;
+
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtProvider {
+
+    @Value("${secret.jwt-secret-key}")
+    private String JWT_SECRET_KEY;
+
+    @Value("${secret.jwt-expired-in.access-token}")
+    private long JWT_EXPIRED_IN;
+
+    public AuthTokens createToken(long memberId) {
+        Claims claims = Jwts.claims()
+                .setSubject(String.valueOf(memberId))
+                .setIssuer("nyeoreumnagi");
+
+        Date now = new Date();
+        Date accessTokenExpiredAt = new Date(now.getTime() + JWT_EXPIRED_IN);
+
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(accessTokenExpiredAt)
+                .signWith(SignatureAlgorithm.HS256, JWT_SECRET_KEY)
+                .compact();
+
+        UUID refreshToken = UUID.randomUUID();
+
+        return AuthTokens.of(accessToken, refreshToken, JWT_EXPIRED_IN);
+    }
+
+    public boolean isExpiredToken(String token){
+        try {
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(JWT_SECRET_KEY).build()
+                    .parseClaimsJws(token);
+            return claims.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            return true;
+        }
+    }
+
+    public Long getMemberId(String token) {
+        String rawMemberId=  Jwts.parserBuilder()
+                .setSigningKey(JWT_SECRET_KEY).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+
+        return Long.parseLong(rawMemberId);
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/jwt/JwtProvider.java
@@ -33,7 +33,7 @@ public class JwtProvider {
 
         UUID refreshToken = UUID.randomUUID();
 
-        return AuthTokens.of(accessToken, refreshToken, JWT_EXPIRED_IN);
+        return AuthTokens.of(accessToken, refreshToken);
     }
 
     public boolean isExpiredToken(String token){

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/WebConfig.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/WebConfig.java
@@ -1,0 +1,34 @@
+package com.imsnacks.Nyeoreumnagi.common.config;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.argumentResolver.JwtAuthHandlerArgumentResolver;
+import com.imsnacks.Nyeoreumnagi.common.auth.interceptor.JwtAuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtAuthInterceptor jwtAuthenticationInterceptor;
+    private final JwtAuthHandlerArgumentResolver jwtAuthHandlerArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(jwtAuthenticationInterceptor)
+                .order(1)
+                .addPathPatterns() //TODO: interceptor를 적용할 url pattern 지정
+                .excludePathPatterns(); //TODO: interceptor를 적용하지 않을 url pattern 지정
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(jwtAuthHandlerArgumentResolver);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,3 +23,8 @@ spring:
     password:
   jpa:
     hibernate.ddl-auto: update
+
+secret:
+  jwt-secret-key: ${JWT_SECRET_KEY}
+  jwt-expired-in:
+    access-token: ${ACCESS_TOKEN_EXPIRED_IN}

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/NyeoreumnagiApplicationTests.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/NyeoreumnagiApplicationTests.java
@@ -3,7 +3,6 @@ package com.imsnacks.Nyeoreumnagi;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class NyeoreumnagiApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthHandlerArgumentResolverTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthHandlerArgumentResolverTest.java
@@ -1,0 +1,65 @@
+package com.imsnacks.Nyeoreumnagi.authTest;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.annotation.PreAuthorize;
+import com.imsnacks.Nyeoreumnagi.common.auth.argumentResolver.JwtAuthHandlerArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.lang.reflect.Method;
+import static org.assertj.core.api.Assertions.*;
+
+public class JwtAuthHandlerArgumentResolverTest {
+
+    JwtAuthHandlerArgumentResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new JwtAuthHandlerArgumentResolver();
+    }
+
+    @Test
+    void 커스텀_어노테이션_타입_판단_성공() throws Exception {
+        // given
+        Method method = TestController.class.getMethod("testMethod", long.class, String.class);
+        MethodParameter paramWithAnno = new MethodParameter(method, 0);
+        MethodParameter paramWithoutAnno = new MethodParameter(method, 1);
+
+        // when
+        boolean resultWithAnno = resolver.supportsParameter(paramWithAnno);
+        boolean resultWithoutAnno = resolver.supportsParameter(paramWithoutAnno);
+
+        // then
+        assertThat(resultWithAnno).isTrue();
+        assertThat(resultWithoutAnno).isFalse();
+    }
+
+    @Test
+    void 토큰의_멤버_아이디_추출_성공() throws Exception {
+        // given
+        Method method = TestController.class.getMethod("testMethod", long.class, String.class);
+        MethodParameter paramWithAnno = new MethodParameter(method, 0);
+
+        HttpServletRequest servletRequest = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(servletRequest.getAttribute("memberId")).thenReturn(42L);
+
+        NativeWebRequest webRequest = new ServletWebRequest(servletRequest);
+        ModelAndViewContainer container = new ModelAndViewContainer();
+
+        // when
+        Object resolved = resolver.resolveArgument(paramWithAnno, container, webRequest, null);
+
+        // then
+        assertThat(resolved).isEqualTo(42L);
+    }
+
+    private static class TestController {
+        public void testMethod(@PreAuthorize long memberId, String another) {}
+    }
+}

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthHandlerArgumentResolverTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthHandlerArgumentResolverTest.java
@@ -27,7 +27,7 @@ public class JwtAuthHandlerArgumentResolverTest {
     @Test
     void 커스텀_어노테이션_타입_판단_성공() throws Exception {
         // given
-        Method method = TestController.class.getMethod("testMethod", long.class, String.class);
+        Method method = TestController.class.getMethod("testMethod", Long.class, String.class);
         MethodParameter paramWithAnno = new MethodParameter(method, 0);
         MethodParameter paramWithoutAnno = new MethodParameter(method, 1);
 
@@ -43,7 +43,7 @@ public class JwtAuthHandlerArgumentResolverTest {
     @Test
     void 토큰의_멤버_아이디_추출_성공() throws Exception {
         // given
-        Method method = TestController.class.getMethod("testMethod", long.class, String.class);
+        Method method = TestController.class.getMethod("testMethod", Long.class, String.class);
         MethodParameter paramWithAnno = new MethodParameter(method, 0);
 
         HttpServletRequest servletRequest = Mockito.mock(HttpServletRequest.class);
@@ -60,6 +60,6 @@ public class JwtAuthHandlerArgumentResolverTest {
     }
 
     private static class TestController {
-        public void testMethod(@PreAuthorize long memberId, String another) {}
+        public void testMethod(@PreAuthorize Long memberId, String another) {}
     }
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthInterceptorTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtAuthInterceptorTest.java
@@ -1,0 +1,116 @@
+package com.imsnacks.Nyeoreumnagi.authTest;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.exception.AuthResponseStatus;
+import com.imsnacks.Nyeoreumnagi.common.auth.exception.JwtException;
+import com.imsnacks.Nyeoreumnagi.common.auth.interceptor.JwtAuthInterceptor;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+class JwtAuthInterceptorTest {
+
+    private JwtProvider jwtProvider;
+    private JwtAuthInterceptor interceptor;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = mock(JwtProvider.class);
+        interceptor = new JwtAuthInterceptor(jwtProvider);
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+    }
+
+    @Test
+    void OPTIONS_요청_통과_성공() {
+        //given
+        when(request.getMethod()).thenReturn(HttpMethod.OPTIONS.name());
+
+        //when
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 토큰_없는_경우_예외() {
+        //given
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader(HttpHeaders.COOKIE)).thenReturn(null);
+
+        //when
+        //then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(JwtException.class)
+                .extracting("status").isEqualTo(AuthResponseStatus.TOKEN_NOT_FOUND);
+    }
+
+    @Test
+    void 토큰_타입_불일치_예외() {
+        //given
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader(HttpHeaders.COOKIE)).thenReturn("FOO token");
+
+        //when
+        //then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(JwtException.class)
+                .extracting("status").isEqualTo(AuthResponseStatus.UNSUPPORTED_TOKEN_TYPE);
+    }
+
+    @Test
+    void 만료된_토큰_예외() {
+        //given
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader(HttpHeaders.COOKIE)).thenReturn("Bearer xxxx");
+        when(jwtProvider.isExpiredToken("xxxx")).thenReturn(true);
+
+        //when
+        //then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(JwtException.class)
+                .extracting("status").isEqualTo(AuthResponseStatus.EXPIRED_TOKEN);
+    }
+
+    @Test
+    void 멤버_ID_없으면_예외() {
+        //given
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader(HttpHeaders.COOKIE)).thenReturn("Bearer xxxx");
+        when(jwtProvider.isExpiredToken("xxxx")).thenReturn(false);
+        when(jwtProvider.getMemberId("xxxx")).thenReturn(null);
+
+        //when
+        //then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                .isInstanceOf(JwtException.class)
+                .extracting("status").isEqualTo(AuthResponseStatus.NO_MEMBERID);
+    }
+
+    @Test
+    void 정상토큰_멤버ID_속성설정() {
+        //given
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getHeader(HttpHeaders.COOKIE)).thenReturn("Bearer testtoken");
+        when(jwtProvider.isExpiredToken("testtoken")).thenReturn(false);
+        when(jwtProvider.getMemberId("testtoken")).thenReturn(123L);
+
+        //when
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        //then
+        assertThat(result).isTrue();
+        verify(request).setAttribute("memberId", 123L);
+    }
+}

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtProviderTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtProviderTest.java
@@ -1,0 +1,95 @@
+package com.imsnacks.Nyeoreumnagi.authTest;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtProviderTest {
+
+    JwtProvider provider;
+    private static final String testSecretKey = "0123456789012345678901234567890101234567890123456789012345678901";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        provider = new JwtProvider();
+
+        Field key = provider.getClass().getDeclaredField("JWT_SECRET_KEY");
+        key.setAccessible(true);
+        key.set(provider, testSecretKey);
+        Field expired = provider.getClass().getDeclaredField("JWT_EXPIRED_IN");
+        expired.setAccessible(true);
+        expired.set(provider, 60000L);
+    }
+
+    @Test
+    void 토큰_생성_성공() {
+        //given
+        //when
+        AuthTokens tokens = provider.createToken(77L);
+        Long memberId = provider.getMemberId(tokens.getAccessToken());
+
+        //then
+        assertThat(tokens.getAccessToken()).isNotNull();
+        assertThat(tokens.getRefreshToken()).isInstanceOf(UUID.class);
+        assertThat(tokens.getExpiresIn()).isEqualTo(60000L);
+        assertThat(memberId).isEqualTo(77L);
+    }
+
+    @Test
+    void 토큰_만료기간_판단_성공() {
+        //given
+        AuthTokens tokens = provider.createToken(1L);
+
+        //when
+        boolean expired = provider.isExpiredToken(tokens.getAccessToken());
+
+        //then
+        assertThat(expired).isFalse();
+    }
+
+    @Test
+    void 토큰_만료기간_지나면_false_반환_성공() throws Exception {
+        //given
+        Claims claims = Jwts.claims().setSubject("10").setIssuer("nyeoreumnagi");
+        Date now = new Date();
+        Date old = new Date(now.getTime() - 60000);
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(old)
+                .signWith(io.jsonwebtoken.SignatureAlgorithm.HS256, testSecretKey)
+                .compact();
+
+        //when
+        boolean expired = provider.isExpiredToken(token);
+
+        //then
+        assertThat(expired).isTrue();
+    }
+
+    @Test
+    void 유효하지_않은_멤버_id_거르기_성공() {
+        //given
+        String token = Jwts.builder()
+                .setSubject("hello")
+                .setIssuedAt(new java.util.Date())
+                .setExpiration(new java.util.Date(System.currentTimeMillis() + 10000))
+                .setIssuer("test")
+                .signWith(io.jsonwebtoken.SignatureAlgorithm.HS256, testSecretKey)
+                .compact();
+
+        //when
+        //then
+        assertThatThrownBy(() -> provider.getMemberId(token))
+                .isInstanceOf(NumberFormatException.class);
+    }
+}

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtProviderTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/authTest/JwtProviderTest.java
@@ -40,7 +40,6 @@ class JwtProviderTest {
         //then
         assertThat(tokens.getAccessToken()).isNotNull();
         assertThat(tokens.getRefreshToken()).isInstanceOf(UUID.class);
-        assertThat(tokens.getExpiresIn()).isEqualTo(60000L);
         assertThat(memberId).isEqualTo(77L);
     }
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #113 

---

## 📝작업 내용

1. Jwt 생성/파싱을 위한 JwtProvider 클래스 생성
2. Controller 진입 전 request를 검증하는 interceptor 클래스 구현
3. interceptor에서 가져온 멤버 id를 controller 에서 받기 위한 argument resolver 구현 (커스텀 어노테이션 적용)
4. 각 클래스 테스트 코드 작성
5. 커스텀 예외 반환

---

## 💬리뷰 요구사항

리팩토링 할 부분 및 논리적 오류 검증 부탁드립니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)