### PR TITLE
[Feat] 농작업 삭제 및 Swagger 에서 memberId 파라미터 숨김 처리

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -81,5 +81,10 @@ jobs:
             echo "DOCKER_REPOSITORY=${{ secrets.DOCKER_REPOSITORY }}" >> ./.env
             echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> ./.env
             echo "ACCESS_TOKEN_EXPIRED_IN=${{ secrets.ACCESS_TOKEN_EXPIRED_IN }}" >> ./.env
+            echo "RDS_ENDPOINT=${{ secrets.RDS_ENDPOINT }}" >> ./.env
+            echo "RDS_PORT=${{ secrets.RDS_PORT }}" >> ./.env
+            echo "RDS_DATABASE=${{ secrets.RDS_DATABASE }}" >> ./.env
+            echo "RDS_USERNAME=${{ secrets.RDS_USERNAME }}" >> ./.env
+            echo "RDS_PASSWORD=${{ secrets.RDS_PASSWORD }}" >> ./.env
             chmod +x deploy.sh
             source deploy.sh

--- a/backend/.deploy/Dockerfile
+++ b/backend/.deploy/Dockerfile
@@ -4,4 +4,4 @@ ARG JAR_FILE=build/libs/*.jar
 
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.2'
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
 import com.imsnacks.Nyeoreumnagi.work.exception.WorkException;
 import com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus;
+import jakarta.validation.UnexpectedTypeException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,5 +29,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CustomResponseBody<Void>> handleJwtException(JwtException ex) {
         AuthResponseStatus status = ex.getStatus();
         return ResponseUtil.error(status.getCode(), status.getMessage());
+    }
+
+    @ExceptionHandler(UnexpectedTypeException.class)
+    public ResponseEntity<CustomResponseBody<Void>> handleValidationException(UnexpectedTypeException ex) {
+        return ResponseUtil.error(400, ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/SwaggerConfig.java
@@ -3,11 +3,17 @@ package com.imsnacks.Nyeoreumnagi.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
@@ -20,5 +26,21 @@ public class SwaggerConfig {
                 .title("Nyeoreumnagi Swagger")
                 .description("녀름나기 REST API 문서")
                 .version("1.0.0");
+    }
+
+    @Bean
+    public OpenApiCustomizer hideMemberIdParam() {
+        return openApi -> {
+            openApi.getPaths().values().forEach(pathItem -> {
+                pathItem.readOperations().forEach(operation -> {
+                    if (operation.getParameters() != null) {
+                        List<Parameter> filtered = operation.getParameters().stream()
+                                .filter(param -> !"memberId".equals(param.getName()))
+                                .collect(Collectors.toList());
+                        operation.setParameters(filtered);
+                    }
+                });
+            });
+        };
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/WebConfig.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAuthenticationInterceptor)
                 .order(1)
-                .addPathPatterns("/user") //TODO: interceptor를 적용할 url pattern 지정
+                .addPathPatterns("/user", "/myWork") //TODO: interceptor를 적용할 url pattern 지정
                 .excludePathPatterns("/swagger-ui/*"); //TODO: interceptor를 적용하지 않을 url pattern 지정
     }
 

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(nullable = false)
     private String identifier;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
@@ -3,6 +3,8 @@ package com.imsnacks.Nyeoreumnagi.work.controller;
 import com.imsnacks.Nyeoreumnagi.common.CustomResponseBody;
 import com.imsnacks.Nyeoreumnagi.common.ResponseUtil;
 import com.imsnacks.Nyeoreumnagi.common.auth.annotation.PreAuthorize;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.DeleteMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.ResisterMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.ResisterMyWorkResponse;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,7 +30,7 @@ public class MyWorkController {
     @ApiResponse(responseCode = "200", description = "농작업 등록 성공")
     @ApiResponse(responseCode = "400", description = "농작업 등록 실패")
     @PostMapping("")
-    public ResponseEntity<CustomResponseBody<ResisterMyWorkResponse>> registerMyWork(@RequestBody ResisterMyWorkRequest request, @PreAuthorize Long memberId) {
+    public ResponseEntity<CustomResponseBody<ResisterMyWorkResponse>> registerMyWork(@Validated @RequestBody ResisterMyWorkRequest request, @PreAuthorize Long memberId) {
         ResisterMyWorkResponse dto = myWorkService.registerMyWork(request, memberId);
         return ResponseUtil.success(dto);
     }
@@ -37,7 +40,7 @@ public class MyWorkController {
     @ApiResponse(responseCode = "200", description = "농작업 삭제 성공")
     @ApiResponse(responseCode = "400", description = "농작업 삭제 실패")
     @DeleteMapping("")
-    public ResponseEntity<CustomResponseBody<Void>> deleteMyWork(@RequestBody DeleteMyWorkRequest request, @PreAuthorize Long memberId) {
+    public ResponseEntity<CustomResponseBody<Void>> deleteMyWork(@Validated @RequestBody DeleteMyWorkRequest request, @PreAuthorize Long memberId) {
         myWorkService.deleteMyWork(request, memberId);
         return ResponseUtil.success();
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
@@ -3,11 +3,13 @@ package com.imsnacks.Nyeoreumnagi.work.controller;
 import com.imsnacks.Nyeoreumnagi.common.CustomResponseBody;
 import com.imsnacks.Nyeoreumnagi.common.ResponseUtil;
 import com.imsnacks.Nyeoreumnagi.common.auth.annotation.PreAuthorize;
+import com.imsnacks.Nyeoreumnagi.work.dto.request.DeleteMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.ResisterMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.ResisterMyWorkResponse;
 import com.imsnacks.Nyeoreumnagi.work.service.MyWorkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +22,23 @@ import org.springframework.web.bind.annotation.*;
 public class MyWorkController {
     private final MyWorkService myWorkService;
 
+    @SecurityRequirement(name = "BearerAuth")
     @Operation(summary = "농작업 등록")
     @ApiResponse(responseCode = "200", description = "농작업 등록 성공")
+    @ApiResponse(responseCode = "400", description = "농작업 등록 실패")
     @PostMapping("")
     public ResponseEntity<CustomResponseBody<ResisterMyWorkResponse>> registerMyWork(@RequestBody ResisterMyWorkRequest request, @PreAuthorize Long memberId) {
         ResisterMyWorkResponse dto = myWorkService.registerMyWork(request, memberId);
         return ResponseUtil.success(dto);
+    }
 
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "농작업 삭제")
+    @ApiResponse(responseCode = "200", description = "농작업 삭제 성공")
+    @ApiResponse(responseCode = "400", description = "농작업 삭제 실패")
+    @DeleteMapping("")
+    public ResponseEntity<CustomResponseBody<Void>> deleteMyWork(@RequestBody DeleteMyWorkRequest request, @PreAuthorize Long memberId) {
+        myWorkService.deleteMyWork(request, memberId);
+        return ResponseUtil.success();
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
@@ -1,0 +1,3 @@
+package com.imsnacks.Nyeoreumnagi.work.dto.request;
+
+public record DeleteMyWorkRequest (long myWorkId){}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
@@ -1,3 +1,5 @@
 package com.imsnacks.Nyeoreumnagi.work.dto.request;
 
-public record DeleteMyWorkRequest (long myWorkId){}
+import jakarta.validation.constraints.NotBlank;
+
+public record DeleteMyWorkRequest (@NotBlank long myWorkId){}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/ResisterMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/ResisterMyWorkRequest.java
@@ -1,4 +1,6 @@
 package com.imsnacks.Nyeoreumnagi.work.dto.request;
 
-public record ResisterMyWorkRequest(long recommendedWorkId, long myCropId, String startTime, String endTime) {
+import jakarta.validation.constraints.NotBlank;
+
+public record ResisterMyWorkRequest(@NotBlank long recommendedWorkId, @NotBlank long myCropId, @NotBlank String startTime, @NotBlank String endTime) {
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
@@ -3,7 +3,8 @@ package com.imsnacks.Nyeoreumnagi.work.exception;
 public enum WorkResponseStatus {
     RECOMMENDED_WORK_NOT_FOUND(7001, "해당 추천 농작업이 존재하지 않습니다."),
     MY_CROP_NOT_FOUND(7002, "내 작물이 존재하지 않습니다."),
-    INVALID_MY_WORK_TIME(7003, "농작업 시간이 유효하지 않습니다.")
+    INVALID_MY_WORK_TIME(7003, "농작업 시간이 유효하지 않습니다."),
+    MY_WORK_NOT_FOUND(7004, "해당 작업이 존재하지 않습니다.")
     ;
 
     private int code;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
@@ -26,14 +26,10 @@ import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.*;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MyWorkService {
-    @Autowired
-    private MyWorkRepository myWorkRepository;
-    @Autowired
-    private RecommendedWorkRepository recommendedWorkRepository;
-    @Autowired
-    private MyCropRepository myCropRepository;
-    @Autowired
-    private MemberRepository memberRepository;
+    private final MyWorkRepository myWorkRepository;
+    private final RecommendedWorkRepository recommendedWorkRepository;
+    private final MyCropRepository myCropRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public ResisterMyWorkResponse registerMyWork(ResisterMyWorkRequest request, Long memberId) {

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
@@ -3,6 +3,7 @@ package com.imsnacks.Nyeoreumnagi.work.service;
 import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
+import com.imsnacks.Nyeoreumnagi.work.dto.request.DeleteMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.ResisterMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.ResisterMyWorkResponse;
 import com.imsnacks.Nyeoreumnagi.work.entity.MyCrop;
@@ -34,8 +35,9 @@ public class MyWorkService {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Transactional
     public ResisterMyWorkResponse registerMyWork(ResisterMyWorkRequest request, Long memberId) {
-        if (!validateTime(request.startTime(), request.endTime())){
+        if (!validateTime(request.startTime(), request.endTime())) {
             throw new WorkException(INVALID_MY_WORK_TIME);
         }
 
@@ -57,5 +59,14 @@ public class MyWorkService {
 
         MyWork savedMyWork = myWorkRepository.save(myWork);
         return new ResisterMyWorkResponse(savedMyWork.getId());
+    }
+
+    @Transactional
+    public void deleteMyWork(DeleteMyWorkRequest request, Long memberId) {
+        MyWork myWork = myWorkRepository.findById(request.myWorkId()).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
+        if (myWork.getMember().getId() != memberId) {
+            throw new WorkException(MY_WORK_NOT_FOUND);
+        }
+        myWorkRepository.deleteById(request.myWorkId());
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,9 @@ spring:
   jpa:
     hibernate.ddl-auto: update
 
+springdoc:
+  override-with-generic-response: false
+
 secret:
   jwt-secret-key: ${JWT_SECRET_KEY}
   jwt-expired-in:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,28 @@ spring:
   jpa:
     hibernate.ddl-auto: update
 
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:mysql://${RDS_ENDPOINT}:${RDS_PORT}/${RDS_DATABASE}?useSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+---
+
 springdoc:
   override-with-generic-response: false
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #89

---

## 📝작업 내용

1. 농작업 삭제 기능을 구현했습니다. 
2. `Member` 엔티티의 id 타입을 원시타입에서 Wrapper 클래스로 변경했습니다. (Hibernate 권고사항)
3. Swagger 페이지에서 memberId 파라미터를 숨김 처리했습니다.
➡️ `Cookie` 헤더에서 jwt 를 가져와서 처리하여, 사용자가 직접 주입할 필요가 없기 때문입니다.
4. RestControllerDevice와 Swagger 충돌을 해결하기 위해 application.yml에 `override-with-generic-response: false` 옵션을 추가했습니다.
5. 배포 시 배포용 RDS 서버와 연결되도록 하기 위해 spring active profile을 `local`과 `prod` 로 나누고 프로퍼티를 다르게 설정했습니다.
5-1. Docker 이미지 생성 시 `prod` 프로필로 생성할 수 있도록 Dockerfile를 변경했습니다. 
6. CD 워크플로우에 RDS 관련 환경 변수를 추가했습니다. 
6-1. EC2 인스턴스 내부의 docker-compose 파일들에도 모두 동일하게 추가했습니다.

> 🔔 인프라 내부의 파일들을 원활히 관리하기 위해 노션에 **파일 정보와 최근 수정일을 관리할 수 있는 데이터베이스**를 구성했습니다.  (`AWS EC2 내부 파일 정보`  페이지  참고)

---

### 🙏 참고 사항

1. 이 서비스에서는 accessToken을 **Authorization** 헤더가 아닌 **Cookie** 헤더에서 가져오기 때문에 메서드에 붙인 `@SecurityRequirement` 는 의미적으로는 옳지 않습니다. 즉 Swagger 페이지에서도 **Authorize** 버튼을 활성화하더라도 사용이 불가능합니다. 그럼에도 불구하고 해당 애너테이션을 붙인 이유는 개발자가 accessToken 필요 여부를 확인할 수 있도록 하기 위함입니다. 

---

## 💬리뷰 요구사항

- @imscow11253 **Cookie** 헤더와 관련해 질문이자 요청사항있습니다! 브라우저가 Cookie 헤더에 값을 담아보낼 때 `key=value` 형식이기 때문에 이 서비스의 경우는 `Cookie : accessToken=sfdfkdsfdsf....` 와 같은 형식으로 올 것 같습니다. 이 형식을 처리할 수 있도록 변경이 필요할 것 같은데 맞는지 확인 부탁드립니다. 😊

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)