### PR TITLE
[fix] 프론트엔드 cd pnpm 설치 에러 수정, 시크릿 키 테스트용 코드 추가

### DIFF
--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -10,16 +10,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: "pnpm"
 
       - name: Install PNPM
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
 
       - name: Install dependencies
         working-directory: ./frontend
@@ -29,13 +30,39 @@ jobs:
         working-directory: ./frontend
         run: pnpm run build
 
+      - name: Debug Secrets
+        if: success()
+        run: |
+          echo "Checking if AWS secrets are set..."
+          if [ -n "${{ secrets.AWS_FE_ACCESS_KEY }}" ]; then
+            echo "AWS_FE_ACCESS_KEY is set"
+          else
+            echo "AWS_FE_ACCESS_KEY is NOT set"
+          fi
+          if [ -n "${{ secrets.AWS_FE_SECRET_ACCESS_KEY }}" ]; then
+            echo "AWS_SECRET_ACCESS_KEY is set"
+          else
+            echo "AWS_SECRET_ACCESS_KEY is NOT set"
+          fi
+          if [ -n "${{ secrets.AWS_FE_REGION }}" ]; then
+            echo "AWS_REGION is set: ${{ secrets.AWS_FE_REGION }}"
+          else
+            echo "AWS_REGION is NOT set"
+          fi
+
       - name: Configure AWS Credentials
         if: success()
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_FE_ACCESS_KEY_ID }}
+          aws-access-key-id: ${{ secrets.AWS_FE_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_FE_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_FE_REGION }}
+
+      - name: Test AWS Configuration
+        if: success()
+        run: |
+          echo "Testing AWS configuration..."
+          aws sts get-caller-identity
 
       - name: Sync to S3
         if: success()


### PR DESCRIPTION
## 📌 연관된 이슈

- close #138 

---

## 📝작업 내용
<img width="1325" height="395" alt="스크린샷 2025-08-09 오전 2 08 06" src="https://github.com/user-attachments/assets/94482c8f-b27c-46a6-95eb-c64a2b8585a8" />

https://pnpm.io/continuous-integration

npm -g install pnpm을 해도 설치가 안된다는 오류가 떠서 확인해보니 pnpm 공식 문서를 확인해보았는데, 

- name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: 22

      - name: Install PNPM
        uses: pnpm/action-setup@v2

깃허브액션 사용 시 npm -g i pnpm이 아니라 pnpm/action-setup@v2을 이용해 pnpm을 설치할 수 있다고 하네요.


수정 후 깃허브 레포 시크릿 키가 있는지 확인하는 코드도 추가해보았습니다.

포크 한 개인 레포에서는 잘 되었는데 과연 여기서도 잘 될 것인지...? 두근두근

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)