### PR TITLE
[Fix] Member의 refreshToken 데이터 타입을 binary(16) -> VARCHAR(36)으로 변경

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.util.UUID;
 
@@ -29,6 +31,8 @@ public class Member {
     @Column(nullable = false)
     private String phoneNumber;
 
+    @JdbcTypeCode(SqlTypes.VARCHAR)
+    @Column(columnDefinition = "VARCHAR(36)")
     @Setter
     private UUID refreshToken;
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #141

---

## 📝작업 내용
Member의 refreshToken 데이터 타입이 binary(16) 라서 UUID가 저장되지 않는 오류가 있었습니다.
- Member의 refreshToken 데이터 타입을 **binary(16) -> VARCHAR(36)**으로 변경했습니다.

---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)