### PR TITLE
fix: GitHub Discussion 템플릿 상단에서 name, description 필드 삭제

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/공지.yml
+++ b/.github/DISCUSSION_TEMPLATE/공지.yml
@@ -1,5 +1,3 @@
-name: "공지"
-description: "프로젝트와 관련된 중요한 공지를 작성합니다."
 title: "[공지] "
 body:
   - type: markdown

--- a/.github/DISCUSSION_TEMPLATE/논의 공간.yml
+++ b/.github/DISCUSSION_TEMPLATE/논의 공간.yml
@@ -1,5 +1,3 @@
-name: "논의 공간" 
-description: "프로젝트와 관련된 다양한 주제를 토론합니다."
 title: "[논의] "
 body:
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/아이디어.yml
+++ b/.github/DISCUSSION_TEMPLATE/아이디어.yml
@@ -1,5 +1,3 @@
-name: "아이디어"
-description: "새로운 기능 또는 개선 아이디어를 제안합니다."
 title: "[아이디어] "
 body:
   - type: textarea

--- a/.github/DISCUSSION_TEMPLATE/투표.yml
+++ b/.github/DISCUSSION_TEMPLATE/투표.yml
@@ -1,5 +1,3 @@
-name: "투표"
-description: "프로젝트와 관련된 의사결정을 위해 투표를 진행합니다."
 title: "[투표] "
 body:
   - type: textarea


### PR DESCRIPTION
## 📌 연관된 이슈

- close #161 

---

## 📝작업 내용

GitHub Discussion 템플릿 상단에서 name, description 필드를 삭제했습니다. 이게 진짜 원인이었네요.
감사합니다.

---

## 💬리뷰 요구사항

x

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)