### PR TITLE
[Feat] 날씨 정보 페이지 - 일일 최고 자외선 UI 구현

### DIFF
--- a/frontend/src/pages/weatherBoardPage/WeatherBoardPage.style.ts
+++ b/frontend/src/pages/weatherBoardPage/WeatherBoardPage.style.ts
@@ -9,6 +9,7 @@ const WeatherBoardPage = css`
   flex-direction: column;
   align-items: center;
   width: 1328px;
+  margin-bottom: 108px;
 `;
 
 const MyFarmAddress = css`

--- a/frontend/src/pages/weatherBoardPage/WeatherBoardPage.tsx
+++ b/frontend/src/pages/weatherBoardPage/WeatherBoardPage.tsx
@@ -83,7 +83,7 @@ const WeatherBoardPage = () => {
             ${S.WeatherBoardContent}
           `}
         >
-          <WeatherBoardUV />
+          <WeatherBoardUV value={8} startTime="08:00" endTime="18:00" />
           <WeatherBoardDust />
           <WeatherBoardSunset />
         </div>

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.style.ts
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.style.ts
@@ -1,6 +1,8 @@
+import { CommonStyles } from '@/styles/commonStyles';
 import { css } from '@emotion/react';
 
 const WeatherBoardTemperature = css`
+  ${CommonStyles.weatherBoardContainer}
   position: relative;
   padding: 8px 0;
   box-sizing: border-box;
@@ -8,6 +10,13 @@ const WeatherBoardTemperature = css`
   pointer-events: none;
 `;
 
+const WeatherBoardTemperatureTitle = css`
+  position: absolute;
+  top: 16px;
+  left: 20px;
+`;
+
 export default {
   WeatherBoardTemperature,
+  WeatherBoardTemperatureTitle,
 };

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.tsx
@@ -1,5 +1,4 @@
 import { GrayScale } from '@/styles/colors';
-import { CommonStyles } from '@/styles/commonStyles';
 import { Typography } from '@/styles/typography';
 import { WEATHER_CONDITIONS } from '@/types/weather.types';
 import { css } from '@emotion/react';
@@ -84,19 +83,8 @@ const WeatherBoardTemperature = () => {
   );
 
   return (
-    <div
-      css={css`
-        ${CommonStyles.weatherBoardContainer}
-        ${S.WeatherBoardTemperature}
-      `}
-    >
-      <div
-        css={css`
-          position: absolute;
-          top: 16px;
-          left: 20px;
-        `}
-      >
+    <div css={S.WeatherBoardTemperature}>
+      <div css={S.WeatherBoardTemperatureTitle}>
         <h3>최고기온</h3>
         <p>{temperatureData.highestTemperature}°</p>
       </div>

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardTemperature/WeatherBoardTemperature.tsx
@@ -1,7 +1,6 @@
 import { GrayScale } from '@/styles/colors';
 import { Typography } from '@/styles/typography';
 import { WEATHER_CONDITIONS } from '@/types/weather.types';
-import { css } from '@emotion/react';
 import { Line, LineChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
 import { getTemperatureColor } from '../../utils/temperatureUtil';
 import TemperatureDot from '../temperatureDot/TemperatureDot';

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.style.ts
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.style.ts
@@ -1,0 +1,64 @@
+import { GrayScale } from '@/styles/colors';
+import { CommonStyles, FlexStyles } from '@/styles/commonStyles';
+import { Typography } from '@/styles/typography';
+import { css } from '@emotion/react';
+
+const WeatherBoardUV = css`
+  ${CommonStyles.weatherBoardContainer}
+  position: relative;
+  padding-bottom: 12px;
+`;
+
+const WeatherBoardUVTitle = css`
+  position: absolute;
+  top: 16px;
+  left: 20px;
+`;
+
+const WeatherBoardUVContent = css`
+  ${FlexStyles.flexColumn};
+  justify-content: flex-end;
+  height: 100%;
+`;
+
+const WeatherBoardUVSvg = css`
+  margin-bottom: 6px;
+
+  @keyframes drawPath {
+    from {
+      stroke-dasharray: 1000;
+      stroke-dashoffset: 1000;
+    }
+    to {
+      stroke-dasharray: 1000;
+      stroke-dashoffset: 0;
+    }
+  }
+`;
+
+const WeatherBoardUVPath = css`
+  animation: drawPath 2s ease-out forwards;
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+`;
+
+const WeatherBoardUVTimeWrapper = css`
+  ${FlexStyles.flexRow};
+  justify-content: space-between;
+  width: 228px;
+`;
+
+const WeatherBoardUVTime = css`
+  ${Typography.Body_S_400};
+  color: ${GrayScale.White};
+`;
+
+export default {
+  WeatherBoardUV,
+  WeatherBoardUVTitle,
+  WeatherBoardUVContent,
+  WeatherBoardUVSvg,
+  WeatherBoardUVPath,
+  WeatherBoardUVTimeWrapper,
+  WeatherBoardUVTime,
+};

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
@@ -1,11 +1,72 @@
-import { CommonStyles } from '@/styles/commonStyles';
+import { css } from '@emotion/react';
+import { getUVLevelAndColor } from '../../utils/uvUtil';
+import S from './WeatherBoardUV.style';
+import { FlexStyles } from '@/styles/commonStyles';
+import { Typography } from '@/styles/typography';
+import { GrayScale } from '@/styles/colors';
 
-const WeatherBoardUV = () => {
+interface WeatherBoardUVProps {
+  value: number;
+  startTime: string;
+  endTime: string;
+}
+
+const WeatherBoardUV = ({ value, startTime, endTime }: WeatherBoardUVProps) => {
+  const { level, color } = getUVLevelAndColor(value);
+
   return (
-    <div css={CommonStyles.weatherBoardContainer}>
-      <div>
-        <h3>자외선</h3>
-        <p>8</p>
+    <div css={S.WeatherBoardUV}>
+      <h3 css={S.WeatherBoardUVTitle}>자외선</h3>
+      <div css={S.WeatherBoardUVContent}>
+        <div
+          css={css`
+            ${FlexStyles.flexColumn};
+            margin-bottom: 18px;
+          `}
+        >
+          <p>{value}</p>
+          <span css={Typography.Caption_S}>{level}</span>
+        </div>
+        <svg
+          width="428"
+          height="74"
+          viewBox="0 0 428 74"
+          fill="none"
+          css={S.WeatherBoardUVSvg}
+        >
+          <line
+            x1="-4.37114e-08"
+            y1="70.5"
+            x2="427"
+            y2="70.5"
+            stroke={GrayScale.G900}
+          />
+          <path
+            d="M1 71C89.8469 71 133.944 5 213.5 5C303.496 5 333.867 71 428 71"
+            stroke="url(#paint0_linear_11858_5916)"
+            strokeWidth="5"
+            css={S.WeatherBoardUVPath}
+          />
+          <defs>
+            <linearGradient
+              id="paint0_linear_11858_5916"
+              x1="1.83068"
+              y1="41.76"
+              x2="427.141"
+              y2="41.76"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#26A49C" stopOpacity="0" />
+              <stop offset="0.5" stopColor={color} />
+              <stop offset="1" stopColor="#26A49C" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+        </svg>
+
+        <div css={S.WeatherBoardUVTimeWrapper}>
+          <span css={S.WeatherBoardUVTime}>{startTime}</span>
+          <span css={S.WeatherBoardUVTime}>{endTime}</span>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/weatherBoardPage/utils/uvUtil.ts
+++ b/frontend/src/pages/weatherBoardPage/utils/uvUtil.ts
@@ -1,0 +1,11 @@
+import { ColorStatus } from '@/styles/colors';
+
+export const getUVLevelAndColor = (
+  value: number
+): { level: string; color: string } => {
+  if (value < 3) return { level: '낮음', color: ColorStatus.Global.Green };
+  if (value < 6) return { level: '보통', color: ColorStatus.Global.Yellow };
+  if (value < 8) return { level: '높음', color: ColorStatus.Global.Orange };
+  if (value < 11) return { level: '매우높음', color: ColorStatus.Global.Red };
+  return { level: '위험', color: ColorStatus.Global.Red };
+};


### PR DESCRIPTION
## 📌 연관된 이슈

- close #54 

---

## 📝작업 내용
- WeatherBoardUV 컴포넌트 레이아웃 및 스타일링
- `utils` > `uvUtil.ts` - UV값에 따라서 level과 색상 리턴 함수 구현
- 일일 온도 `WeatherBoardTemperature` 스타일 분리
---

### 스크린샷 (선택)

https://github.com/user-attachments/assets/99637994-5792-4d86-acdc-75d03e30b39d


---

## 💬리뷰 요구사항

특별히 없습니다! 한번 보시구 코멘트 할 거 있으면 해주세요!

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)