### PR TITLE
[Fix] 드래그 시 시간 업데이트가 제대로 되지 않는 오류 해결

### DIFF
--- a/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
@@ -48,7 +48,9 @@ const WorkContainer = () => {
       <div
         ref={containerRef}
         onMouseMove={e => {
-          updatePosition(e, (block, pos) => updateBlockWorkTime(block, pos));
+          updatePosition(e, (block, pos) =>
+            updateBlockWorkTime(block, pos, 100)
+          );
         }}
         onMouseUp={handleEndDrag}
         onMouseLeave={handleEndDrag}

--- a/frontend/src/pages/homePage/utils/updateBlockWorkTime.ts
+++ b/frontend/src/pages/homePage/utils/updateBlockWorkTime.ts
@@ -3,10 +3,11 @@ import type { WorkBlockType } from '@/types/workCard.type';
 
 const updateBlockWorkTime = (
   block: WorkBlockType,
-  position: { x: number; y: number }
+  position: { x: number; y: number },
+  px: number
 ) => {
-  const newStartHour = position.x / 100;
-  const newStartMinutes = Math.round((position.x % 100) * 0.6);
+  const newStartHour = position.x / px;
+  const newStartMinutes = Math.round((position.x % px) * 0.6);
 
   const originalStartTime = dayjs(block.startTime);
   const originalEndTime = dayjs(block.endTime);

--- a/frontend/src/pages/homePage/utils/updateBlockWorkTime.ts
+++ b/frontend/src/pages/homePage/utils/updateBlockWorkTime.ts
@@ -5,7 +5,7 @@ const updateBlockWorkTime = (
   block: WorkBlockType,
   position: { x: number; y: number }
 ) => {
-  const newStartHour = Math.round(position.x / 100);
+  const newStartHour = position.x / 100;
   const newStartMinutes = Math.round((position.x % 100) * 0.6);
 
   const originalStartTime = dayjs(block.startTime);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #144
---

## 📝작업 내용

https://github.com/user-attachments/assets/329c791b-d3e7-4859-8ce8-f14453232ba7

현재 분이 30분일 때, 31분으로 이동 시 시간도 함께 증가하는 문제가 있었습니다.

ex) 시간이 6:30분일 때 6:31이 되지 않고 바로 7:31로 넘어감

현재 시간을 position.x를 기반으로 업데이트하는데, Math.round를 반올림을 하여
650->651로 넘어갈 때 반올림이 되어 700이 되는 문제 였습니다.
Math.round 삭제했습니다

---

### 스크린샷 (선택)

https://github.com/user-attachments/assets/886e6093-9950-4f46-a43b-dd58245cae9d

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)