### PR TITLE
[Feat] dnd 충돌 감지 및 충돌 시 겹치지 않는 위치로 이동

### DIFF
--- a/frontend/src/constants/workScheduleData.ts
+++ b/frontend/src/constants/workScheduleData.ts
@@ -61,7 +61,7 @@ export const WORK_SCHEDULE_DATA = [
       {
         id: 6,
         cropName: '단감',
-        workName: '가을 거름',
+        workName: '병해충 방제',
         workTime: '06:20 - 08:10',
         startTime: '2025-08-07T06:20:00',
         endTime: '2025-08-07T08:10:00',

--- a/frontend/src/constants/workScheduleData.ts
+++ b/frontend/src/constants/workScheduleData.ts
@@ -38,7 +38,7 @@ export const WORK_SCHEDULE_DATA = [
     ],
   },
   {
-    date: '2025-08-12',
+    date: '2025-08-13',
     workCardData: [
       {
         id: 4,

--- a/frontend/src/contexts/useWorkBlocks.ts
+++ b/frontend/src/contexts/useWorkBlocks.ts
@@ -3,11 +3,7 @@ import { WorkBlocksContext } from './WorkBlocksContext';
 
 const useWorkBlocks = () => {
   const context = useContext(WorkBlocksContext);
-  if (context === undefined) {
-    throw new Error(
-      'useWorkBlocks는 반드시 WorkBlocksProvider 내에서 사용되어야 합니다'
-    );
-  }
+
   return context;
 };
 

--- a/frontend/src/hooks/dnd/useRevertPosition.ts
+++ b/frontend/src/hooks/dnd/useRevertPosition.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import type { Position } from '@/types/workCard.type';
+import type { Position, Size } from '@/types/workCard.type';
 
 interface RevertPositionProps<T> {
   draggedItem: T | null;
@@ -8,9 +8,7 @@ interface RevertPositionProps<T> {
   initialPosition: Position | null;
 }
 
-export const useRevertPosition = <
-  T extends { width?: number; height?: number }
->({
+export const useRevertPosition = <T extends { size?: Size }>({
   draggedItem,
   onRevert,
   getItemPosition,
@@ -23,8 +21,8 @@ export const useRevertPosition = <
       }
 
       const { x, y } = getItemPosition(draggedItem);
-      const itemWidth = draggedItem.width || 0;
-      const itemHeight = draggedItem.height || 0;
+      const itemWidth = draggedItem.size?.width || 0;
+      const itemHeight = draggedItem.size?.height || 0;
 
       const isWithinBounds =
         x >= 0 + scrollOffset &&

--- a/frontend/src/hooks/dnd/useRevertPosition.ts
+++ b/frontend/src/hooks/dnd/useRevertPosition.ts
@@ -16,6 +16,7 @@ export const useRevertPosition = <T extends { size?: Size }>({
 }: RevertPositionProps<T>) => {
   const checkAndRevert = useCallback(
     (containerRect: DOMRect, scrollOffset: number) => {
+      console.log('checkAndRevert', draggedItem, initialPosition);
       if (!draggedItem || !initialPosition) {
         return;
       }

--- a/frontend/src/hooks/useResizeCollision.ts
+++ b/frontend/src/hooks/useResizeCollision.ts
@@ -1,0 +1,113 @@
+import { useRef, useState } from 'react';
+import type { Position, WorkBlockType } from '@/types/workCard.type';
+import {
+  findCollisionFreePosition,
+  hasCollision,
+} from '@/utils/collisionUtils';
+import animateBlock from '@/utils/animateBlock';
+
+interface UseResizeCollisionProps {
+  containerRef?: React.RefObject<HTMLDivElement | null>;
+  scrollOffset: number;
+  allBlocks: WorkBlockType[];
+  updateWorkBlocks: (blocks: WorkBlockType[]) => void;
+}
+
+export const useResizeCollision = ({
+  containerRef,
+  scrollOffset,
+  allBlocks,
+  updateWorkBlocks,
+}: UseResizeCollisionProps) => {
+  const revertAnimationRef = useRef<number | null>(null);
+  const [isRevertingItemId, setIsRevertingItemId] = useState<number | null>(
+    null
+  );
+
+  // 리사이징 후 충돌 검사 및 위치 조정
+  const handleResizeCollision = (block: WorkBlockType, newWidth: number) => {
+    if (containerRef?.current && allBlocks.length > 0) {
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const currentBlock = {
+        ...block,
+        size: { ...block.size, width: newWidth },
+      };
+
+      const otherBlocks = allBlocks.filter(b => b.id !== block.id);
+      const hasCollisionWithOthers = otherBlocks.some(otherBlock =>
+        hasCollision(currentBlock, otherBlock)
+      );
+
+      if (hasCollisionWithOthers) {
+        const collisionFreePosition = findCollisionFreePosition(
+          currentBlock,
+          otherBlocks,
+          containerRect,
+          scrollOffset
+        );
+
+        setIsRevertingItemId(block.id);
+
+        const latestBlocksRef = { current: allBlocks };
+
+        animateBlock(
+          revertAnimationRef,
+          setIsRevertingItemId,
+          latestBlocksRef,
+          updateWorkBlocks,
+          block.id,
+          currentBlock.position,
+          collisionFreePosition
+        );
+      }
+    }
+  };
+
+  // 드래그 후 충돌 검사 및 위치 조정
+  const handleDragCollision = (
+    draggedBlock: WorkBlockType,
+    targetPosition: Position
+  ) => {
+    if (containerRef?.current && allBlocks.length > 0) {
+      const containerRect = containerRef.current.getBoundingClientRect();
+
+      const otherBlocks = allBlocks.filter(b => b.id !== draggedBlock.id);
+      const hasCollisionWithOthers = otherBlocks.some(otherBlock =>
+        hasCollision({ ...draggedBlock, position: targetPosition }, otherBlock)
+      );
+
+      if (hasCollisionWithOthers) {
+        const collisionFreePosition = findCollisionFreePosition(
+          { ...draggedBlock, position: targetPosition },
+          otherBlocks,
+          containerRect,
+          scrollOffset
+        );
+
+        setIsRevertingItemId(draggedBlock.id);
+
+        const latestBlocksRef = { current: allBlocks };
+
+        animateBlock(
+          revertAnimationRef,
+          setIsRevertingItemId,
+          latestBlocksRef,
+          updateWorkBlocks,
+          draggedBlock.id,
+          targetPosition,
+          collisionFreePosition
+        );
+
+        return collisionFreePosition;
+      }
+    }
+    return targetPosition;
+  };
+
+  return {
+    handleResizeCollision,
+    handleDragCollision,
+    isRevertingItemId,
+    revertAnimationRef,
+  };
+};

--- a/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
@@ -31,8 +31,8 @@ const RegisterWorkContainer = () => {
 
     const newWorkBlock: WorkBlockType = {
       id: Date.now(),
-      position: { x, y: 50 },
-      width,
+      position: { x, y: 40 },
+      size: { width, height: 50 },
       cropName: selectedCrop?.name || '기본',
       workName: workName,
       workTime: '09:00 - 10:00',

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.style.ts
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.style.ts
@@ -3,16 +3,14 @@ import { ColorStatus, GrayScale } from '@/styles/colors';
 import { BorderRadius } from '@/styles/borderRadius';
 import { Spacing } from '@/styles/spacing';
 import { Typography } from '@/styles/typography';
+import type { Size } from '@/types/workCard.type';
 
 interface WorkCardContainerProps {
   isDragging: boolean;
-  width?: number;
+  size: Size;
 }
 
-const WorkCardContainer = ({
-  isDragging,
-  width,
-}: WorkCardContainerProps) => css`
+const WorkCardContainer = ({ isDragging, size }: WorkCardContainerProps) => css`
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -22,7 +20,8 @@ const WorkCardContainer = ({
   border-radius: ${BorderRadius.Base.S_Hard};
   background-color: ${GrayScale.White};
   border: 1px solid ${GrayScale.G200};
-  width: ${width ? `${width}px` : 'auto'};
+  width: ${size.width ? `${size.width}px` : 'auto'};
+  height: ${size.height ? `${size.height}px` : 'auto'};
 
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: ${isDragging ? 1000 : 1};

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
@@ -3,7 +3,7 @@ import WorkCardRegisterContent from '../workCardRegisterContent/WorkCardRegister
 import useVisibility from '@/hooks/useVisibility';
 import { useState } from 'react';
 import type { WorkBlockType } from '@/types/workCard.type';
-import { useResize } from '@/pages/homePage/hooks/useResize';
+import { useChangeTimeByResize } from '@/pages/homePage/hooks/useChangeTimeByResize';
 import { css } from '@emotion/react';
 import { useResizeCollision } from '@/hooks/useResizeCollision';
 
@@ -41,7 +41,7 @@ const WorkCardRegister = ({
     updateWorkBlocks: updateWorkBlocks || (() => {}),
   });
 
-  const { handleResizeStart } = useResize({
+  const { handleResizeStart } = useChangeTimeByResize({
     onResize: newBlock => {
       setNewWidth(newBlock.size.width);
       setIsResizing(true);

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
@@ -22,12 +22,12 @@ const WorkCardRegister = ({
   onResize,
 }: WorkCardRegisterProps) => {
   const { show, hide, isVisible } = useVisibility();
-  const [newWidth, setNewWidth] = useState(block.width);
+  const [newWidth, setNewWidth] = useState(block.size.width);
   const [isResizing, setIsResizing] = useState(false);
 
   const { handleResizeStart } = useResize({
     onResize: newBlock => {
-      setNewWidth(newBlock.width);
+      setNewWidth(newBlock.size.width);
       setIsResizing(true);
       onResize?.(newBlock);
     },
@@ -35,7 +35,13 @@ const WorkCardRegister = ({
 
   return (
     <div
-      css={S.WorkCardContainer({ isDragging, width: newWidth })}
+      css={S.WorkCardContainer({
+        isDragging,
+        size: {
+          width: newWidth,
+          height: block.size.height,
+        },
+      })}
       onMouseDown={onMouseDown}
       onMouseEnter={show}
       onMouseLeave={hide}

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
@@ -94,6 +94,7 @@ const WorkCardRegister = ({
         `}
       >
         <WorkCardRegisterContent
+          width={newWidth}
           cropName={block.cropName}
           workName={block.workName}
           workTime={block.workTime}
@@ -104,7 +105,7 @@ const WorkCardRegister = ({
             onMouseDown={e => e.stopPropagation()}
             css={S.WorkCardDeleteButton}
           >
-            삭제
+            ×
           </button>
         )}
       </div>

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.style.ts
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.style.ts
@@ -28,11 +28,17 @@ const WorkCardInfo = css`
 const WorkCardTitle = css`
   ${Typography.Body_S_400}
   color: ${Assets.Text.WorkCard.Default.Headline};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const WorkCardCropName = css`
   ${Typography.Caption_S}
   color: ${Assets.Text.WorkCard.Default.Headline};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const WorkCardTime = css`

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
@@ -15,6 +15,7 @@ interface WorkCardRegisterProps {
 }
 
 const WorkCardRegisterContent = ({
+  width,
   cropName,
   workName,
   workTime,
@@ -28,20 +29,33 @@ const WorkCardRegisterContent = ({
       <div css={S.WorkCardInfo}>
         <div
           css={css`
-            ${FlexStyles.flexRow} gap:${Spacing.Spacing300}
+            ${FlexStyles.flexRow} gap:${Spacing.Spacing300};
+            ${width &&
+            width < 120 &&
+            css`
+              word-break: break-all;
+            `}
           `}
         >
-          <div css={[S.WorkCardTitle, isCompleted && S.CompletedTextStyle]}>
-            {workName}
-          </div>
-          <div css={[S.WorkCardCropName, isCompleted && S.CompletedTextStyle]}>
-            {' '}
-            {cropName}
-          </div>
+          {width && width > 100 && (
+            <div css={[S.WorkCardTitle, isCompleted && S.CompletedTextStyle]}>
+              {workName}
+            </div>
+          )}
+          {width && width > 120 && (
+            <div
+              css={[S.WorkCardCropName, isCompleted && S.CompletedTextStyle]}
+            >
+              {' '}
+              {cropName}
+            </div>
+          )}
         </div>
-        <div css={[S.WorkCardTime, isCompleted && S.CompletedTextStyle]}>
-          {workTime}
-        </div>
+        {width && width > 120 && (
+          <div css={[S.WorkCardTime, isCompleted && S.CompletedTextStyle]}>
+            {workTime}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
@@ -110,9 +110,7 @@ const WorkContainer = () => {
       if (rect) {
         checkAndRevert(rect, scrollOffset);
       }
-    }
 
-    if (draggingId !== null) {
       const draggingBlock = workBlocks.find(block => block.id === draggingId);
       if (draggingBlock) {
         // 다른 블록과의 충돌 검사

--- a/frontend/src/pages/homePage/hooks/useChangeTimeByResize.ts
+++ b/frontend/src/pages/homePage/hooks/useChangeTimeByResize.ts
@@ -7,7 +7,7 @@ interface UseResizeProps {
   onResize: (newBlock: WorkBlockType) => void;
 }
 
-export const useResize = ({ onResize }: UseResizeProps) => {
+export const useChangeTimeByResize = ({ onResize }: UseResizeProps) => {
   const resizeRef = useRef<{
     startX: number;
     startTime: dayjs.Dayjs;

--- a/frontend/src/pages/homePage/hooks/useResize.ts
+++ b/frontend/src/pages/homePage/hooks/useResize.ts
@@ -23,7 +23,7 @@ export const useResize = ({ onResize }: UseResizeProps) => {
     ) => {
       e.stopPropagation();
 
-      if (!block.width) return;
+      if (!block.size?.width) return;
 
       const startTime = dayjs(block.startTime);
       const endTime = dayjs(block.endTime);
@@ -76,7 +76,7 @@ export const useResize = ({ onResize }: UseResizeProps) => {
           workTime: `${newStartTime.format('HH:mm')} - ${newEndTime.format(
             'HH:mm'
           )}`,
-          width: newWidth,
+          size: { width: newWidth, height: block.size.height },
         });
       };
 

--- a/frontend/src/pages/homePage/utils/getInitialWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/getInitialWorkBlocks.ts
@@ -43,7 +43,7 @@ const getInitialWorkBlocks = (newWorkBlocks?: WorkBlockType[]) => {
       workTime: work.workTime,
       startTime: work.startTime,
       endTime: work.endTime,
-      position: { x, y: 50 }, // 기본 y 위치
+      position: { x, y: 35 }, // 기본 y 위치
       size: { width, height: 52 },
     });
   });

--- a/frontend/src/pages/homePage/utils/getInitialWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/getInitialWorkBlocks.ts
@@ -44,7 +44,7 @@ const getInitialWorkBlocks = (newWorkBlocks?: WorkBlockType[]) => {
       startTime: work.startTime,
       endTime: work.endTime,
       position: { x, y: 50 }, // 기본 y 위치
-      width,
+      size: { width, height: 52 },
     });
   });
 

--- a/frontend/src/types/workCard.type.ts
+++ b/frontend/src/types/workCard.type.ts
@@ -11,6 +11,11 @@ export interface Position {
   y: number;
 }
 
+export interface Size {
+  width: number;
+  height: number;
+}
+
 export interface WorkBlockType {
   id: number;
   cropName: string;
@@ -19,5 +24,5 @@ export interface WorkBlockType {
   startTime: string;
   endTime: string;
   position: Position;
-  width: number;
+  size: Size;
 }

--- a/frontend/src/utils/animateBlock.ts
+++ b/frontend/src/utils/animateBlock.ts
@@ -1,5 +1,5 @@
 import type { Position, WorkBlockType } from '@/types/workCard.type';
-import updateBlockWorkTime from './updateBlockWorkTime';
+import updateBlockWorkTime from '@/pages/homePage/utils/updateBlockWorkTime';
 
 const animateBlock = (
   revertAnimationRef: React.RefObject<number | null>,

--- a/frontend/src/utils/collisionUtils.ts
+++ b/frontend/src/utils/collisionUtils.ts
@@ -1,0 +1,97 @@
+import type { Position, Size, WorkBlockType } from '@/types/workCard.type';
+
+// 충돌 감지 함수
+export const hasCollision = (
+  currentBlock: { position: Position; size: Size },
+  targetBlock: { position: Position; size: Size }
+): boolean => {
+  const currentCenterX = currentBlock.position.x + currentBlock.size.width / 2;
+  const currentCenterY = currentBlock.position.y + currentBlock.size.height / 2;
+
+  const targetCenterX = targetBlock.position.x + targetBlock.size.width / 2;
+  const targetCenterY = targetBlock.position.y + targetBlock.size.height / 2;
+
+  const distanceX = Math.abs(currentCenterX - targetCenterX);
+  const distanceY = Math.abs(currentCenterY - targetCenterY);
+
+  return (
+    distanceX < currentBlock.size.width / 2 + targetBlock.size.width / 2 &&
+    distanceY < currentBlock.size.height / 2 + targetBlock.size.height / 2
+  );
+};
+
+// 컨테이너 경계 내부인지 확인하는 함수
+export const isWithinBounds = (
+  position: Position,
+  size: Size,
+  containerRect: DOMRect,
+  scrollOffset: number
+): boolean => {
+  return (
+    position.x >= 0 + scrollOffset &&
+    position.y >= 0 &&
+    position.x + size.width <= containerRect.width + scrollOffset &&
+    position.y + size.height <= containerRect.height
+  );
+};
+
+// 충돌하지 않는 위치를 찾는 함수
+export const findCollisionFreePosition = (
+  draggedBlock: WorkBlockType,
+  otherBlocks: WorkBlockType[],
+  containerRect: DOMRect,
+  scrollOffset: number
+): Position => {
+  const { position, size } = draggedBlock;
+  let newPosition = { ...position };
+
+  // 다른 블록들과의 충돌 검사
+  const hasCollisionWithOthers = otherBlocks.some(block =>
+    hasCollision(draggedBlock, block)
+  );
+
+  if (hasCollisionWithOthers) {
+    // 충돌이 있으면 가장 가까운 충돌하지 않는 위치 찾기
+    let offset = 10; // 10px씩 이동
+    const maxAttempts = 50; // 최대 시도 횟수
+    let attempts = 0;
+
+    while (hasCollisionWithOthers && attempts < maxAttempts) {
+      // 여러 방향으로 시도
+      const directions = [
+        { x: offset, y: 0 }, // 오른쪽
+        { x: -offset, y: 0 }, // 왼쪽
+        { x: 0, y: offset }, // 아래
+        { x: 0, y: -offset }, // 위
+      ];
+
+      for (const direction of directions) {
+        const testPosition = {
+          x: position.x + direction.x,
+          y: position.y + direction.y,
+        };
+
+        // 컨테이너 경계 내부인지 확인
+        if (!isWithinBounds(testPosition, size, containerRect, scrollOffset)) {
+          continue; // 경계를 벗어나면 다음 방향 시도
+        }
+
+        // 테스트 위치에서 충돌 검사
+        const testBlock = { ...draggedBlock, position: testPosition };
+        const testHasCollision = otherBlocks.some(block =>
+          hasCollision(testBlock, block)
+        );
+
+        if (!testHasCollision) {
+          newPosition = testPosition;
+          return newPosition;
+        }
+      }
+
+      offset += 10;
+      attempts++;
+    }
+  }
+
+  return newPosition;
+};


### PR DESCRIPTION
## 📌 연관된 이슈

- close #147 

---

## 📝작업 내용

- 렌더링 횟수를 줄이기 위해 workBlocks를 setState로 관리하고, 현재 드래그 중인 아이템을 draggingItem라는 state로 따로 관리하여 드래그 중일 때는 draggingItem만 업데이트하는 로직을 구상했었습니다.
- 다만 그렇게 하니 충돌 처리 시 마우스를 놓으면 draggingItem의 position이 업데이트되어야하는데, setWorkBlocks 후에 setDraggingItem이 실행되니 draggingItem의 업데이트가 약간..! 늦어져 애니메이션이 자연스럽게 이뤄지지 않고 잠깐 잔상이 보이는 문제가 있어, draggingItem을 state로 관리하지 않고 workBlocks에서 id로 find해서 찾는 로직으로 복구했습니다

기능 개발하면서 일어나는 문제의 70퍼센트가 setState의 상태 동기화 문제인 것 같은데 어렵네요...

TODO
1. 이동 시 y축 고정시키기
2. 처음 데이터 렌더링 시 startTime, endTime 겹치는 부분 계산해서 y축 변경하기

---

### 스크린샷 (선택)

https://github.com/user-attachments/assets/b0ebb8e8-8845-450a-92a0-8f384bc686c9


---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)