### PR TITLE
[Feat] 로그인 Response에 사용자 nickname 추가

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.controller;
 
 import com.imsnacks.Nyeoreumnagi.common.auth.dto.request.LoginRequest;
-import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse;
 import com.imsnacks.Nyeoreumnagi.common.auth.service.AuthService;
 import com.imsnacks.Nyeoreumnagi.common.response.CustomResponseBody;
 import com.imsnacks.Nyeoreumnagi.common.response.ResponseUtil;
@@ -27,8 +27,8 @@ public class AuthController {
     @Operation(summary = "로그인")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @ApiResponse(responseCode = "400", description = "로그인 실패")
-    public ResponseEntity<CustomResponseBody<AuthTokens>> login(@RequestBody @Validated LoginRequest request){
-        AuthTokens authTokens = authService.login(request);
-        return ResponseUtil.success(authTokens);
+    public ResponseEntity<CustomResponseBody<LoginResponse>> login(@RequestBody @Validated LoginRequest request){
+        LoginResponse response = authService.login(request);
+        return ResponseUtil.success(response);
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/response/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.dto.response;
+
+import java.util.UUID;
+
+public record LoginResponse(
+        String nickname,
+        String accessToken,
+        UUID refreshToken
+) {
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.service;
 
 import com.imsnacks.Nyeoreumnagi.common.auth.dto.request.LoginRequest;
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse;
 import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
 import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
 import com.imsnacks.Nyeoreumnagi.member.entity.Member;
@@ -20,7 +21,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
 
     @Transactional
-    public AuthTokens login(LoginRequest request){
+    public LoginResponse login(LoginRequest request){
         Member member = memberRepository.findOneByIdentifier(request.identifier()).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         if (!member.getPassword().equals(request.password())){
@@ -30,6 +31,6 @@ public class AuthService {
         AuthTokens token = jwtProvider.createToken(member.getId());
         member.setRefreshToken(token.getRefreshToken());
 
-        return token;
+        return new LoginResponse(member.getNickname(), token.getAccessToken(), token.getRefreshToken());
     }
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.controller;
 
 import com.imsnacks.Nyeoreumnagi.common.auth.dto.request.LoginRequest;
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse;
 import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
 import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
 import com.imsnacks.Nyeoreumnagi.common.auth.service.AuthService;
@@ -8,24 +9,17 @@ import com.imsnacks.Nyeoreumnagi.member.entity.Farm;
 import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus.INCORRECT_PASSWORD;
-import static com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus.MEMBER_NOT_FOUND;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
@@ -60,10 +54,10 @@ class AuthControllerTest {
 
         LoginRequest request = new LoginRequest("testUser", "1234");
 
-        AuthTokens tokens = authService.login(request);
+        LoginResponse response = authService.login(request);
 
-        assertThat(tokens.getAccessToken()).isEqualTo(accessToken);
-        assertThat(tokens.getRefreshToken()).isEqualTo(refreshToken);
+        assertThat(response.accessToken()).isEqualTo(accessToken);
+        assertThat(response.refreshToken()).isEqualTo(refreshToken);
 
         verify(memberRepository, times(1)).findOneByIdentifier(identifier);
         verify(jwtProvider, times(1)).createToken(1L);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #255

---

## 📝작업 내용

- 로그인 Response에 사용자 nickname 을 추가했습니다.
- `AuthTokens` 클래스 객체를 반환하지 않고 `LoginResponse` Dto를 반환하도록 개선했습니다.

---

### 응답 예시

```json
{
    "code": 200,
    "msg": "요청이 성공적으로 처리되었습니다.",
    "data": {
        "nickname": "농부킹",
        "accessToken": "eyJhbGciOiJIUuYWdpIiwiaWF0IjoNzV9.DDA6RZmjmfcJmcPtkcfMK6PGRF7chjiT3r9VVqiaVFM(생략)",
        "refreshToken": "ad88-4770f3ec(생략)"
    }
}
```

---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)