### PR TITLE
[Feat] 요청 값이 null인 경우에 code 세분화

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
@@ -27,7 +27,8 @@ public class AuthController {
     @Operation(summary = "로그인")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @ApiResponse(responseCode = "400", description = "로그인 실패")
-    public ResponseEntity<CustomResponseBody<LoginResponse>> login(@RequestBody @Validated LoginRequest request){
+    public ResponseEntity<CustomResponseBody<LoginResponse>> login(@RequestBody LoginRequest request){
+        request.validate();
         LoginResponse response = authService.login(request);
         return ResponseUtil.success(response);
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/request/LoginRequest.java
@@ -1,11 +1,21 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+
+import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
+
+import static com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus.BLANK_IDENTIFIER;
+import static com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus.BLANK_PASSWORD;
 
 public record LoginRequest(
-        @NotBlank
         String identifier,
-        @NotBlank
         String password
 ) {
+    public void validate(){
+        if(identifier.isBlank()){
+            throw new MemberException(BLANK_IDENTIFIER);
+        }
+        if(password.isBlank()){
+            throw new MemberException(BLANK_PASSWORD);
+        }
+    }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/exception/MemberResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/exception/MemberResponseStatus.java
@@ -4,7 +4,9 @@ public enum MemberResponseStatus {
     MEMBER_NOT_FOUND(2001, "회원 정보가 존재하지 않습니다."),
     INVALID_MEMBER_ID(2002, "memberId에 일치하는 member가 존재하지 않습니다."),
     NO_FARM_INFO(2003, "해당 멤버는 농장 정보가 없습니다."),
-    INCORRECT_PASSWORD(2004, "비밀번호가 옳지 않습니다.")
+    INCORRECT_PASSWORD(2004, "비밀번호가 옳지 않습니다."),
+    BLANK_IDENTIFIER(2005, "identifer가 비어있습니다."),
+    BLANK_PASSWORD(2005, "password가 비어있습니다.")
     ;
 
     private int code;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -33,7 +32,8 @@ public class MyWorkController {
     @ApiResponse(responseCode = "200", description = "농작업 등록 성공")
     @ApiResponse(responseCode = "400", description = "농작업 등록 실패")
     @PostMapping("")
-    public ResponseEntity<CustomResponseBody<RegisterMyWorkResponse>> registerMyWork(@Validated @RequestBody RegisterMyWorkRequest request, @PreAuthorize Long memberId) {
+    public ResponseEntity<CustomResponseBody<RegisterMyWorkResponse>> registerMyWork(@RequestBody RegisterMyWorkRequest request, @PreAuthorize Long memberId) {
+        request.validate();
         RegisterMyWorkResponse dto = myWorkService.registerMyWork(request, memberId);
         return ResponseUtil.success(dto);
     }
@@ -43,7 +43,8 @@ public class MyWorkController {
     @ApiResponse(responseCode = "200", description = "농작업 삭제 성공")
     @ApiResponse(responseCode = "400", description = "농작업 삭제 실패")
     @DeleteMapping("")
-    public ResponseEntity<CustomResponseBody<Void>> deleteMyWork(@Validated @RequestBody DeleteMyWorkRequest request, @PreAuthorize Long memberId) {
+    public ResponseEntity<CustomResponseBody<Void>> deleteMyWork(@RequestBody DeleteMyWorkRequest request, @PreAuthorize Long memberId) {
+        request.validate();
         myWorkService.deleteMyWork(request, memberId);
         return ResponseUtil.success();
     }
@@ -53,7 +54,8 @@ public class MyWorkController {
     @ApiResponse(responseCode = "200", description = "농작업 수정 성공")
     @ApiResponse(responseCode = "400", description = "농작업 수정 실패")
     @PatchMapping("")
-    public ResponseEntity<CustomResponseBody<ModifyMyWorkResponse>> modifyMyWork(@Validated @RequestBody ModifyMyWorkRequest request, @PreAuthorize Long memberId) {
+    public ResponseEntity<CustomResponseBody<ModifyMyWorkResponse>> modifyMyWork(@RequestBody ModifyMyWorkRequest request, @PreAuthorize Long memberId) {
+        request.validate();
         ModifyMyWorkResponse modifyMyWorkResponse = myWorkService.modifyMyWork(request, memberId);
         return ResponseUtil.success(modifyMyWorkResponse);
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/DeleteMyWorkRequest.java
@@ -1,5 +1,14 @@
 package com.imsnacks.Nyeoreumnagi.work.dto.request;
 
+import com.imsnacks.Nyeoreumnagi.work.exception.WorkException;
 import jakarta.validation.constraints.NotNull;
 
-public record DeleteMyWorkRequest (@NotNull Long myWorkId){}
+import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.NULL_MY_WORK_ID;
+
+public record DeleteMyWorkRequest (@NotNull Long myWorkId){
+    public void validate(){
+        if(myWorkId == null){
+            throw new WorkException(NULL_MY_WORK_ID);
+        }
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/ModifyMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/ModifyMyWorkRequest.java
@@ -1,10 +1,14 @@
 package com.imsnacks.Nyeoreumnagi.work.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.imsnacks.Nyeoreumnagi.work.exception.WorkException;
+import com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+
+import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.*;
 
 public record ModifyMyWorkRequest(
         @NotNull
@@ -16,4 +20,15 @@ public record ModifyMyWorkRequest(
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime endTime
 ) {
+    public void validate() {
+        if (myWorkId == null) {
+            throw new WorkException(NULL_MY_WORK_ID);
+        }
+        if (startTime == null) {
+            throw new WorkException(NULL_START_TIME);
+        }
+        if (endTime == null) {
+            throw new WorkException(NULL_END_TIME);
+        }
+    }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/RegisterMyWorkRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/RegisterMyWorkRequest.java
@@ -1,20 +1,28 @@
 package com.imsnacks.Nyeoreumnagi.work.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import com.imsnacks.Nyeoreumnagi.work.exception.WorkException;
 
 import java.time.LocalDateTime;
 
+import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.*;
+
 public record RegisterMyWorkRequest(
-        @NotNull
         Long recommendedWorkId,
-        @NotNull
         Long myCropId,
-        @NotNull
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime startTime,
-        @NotNull
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
         LocalDateTime endTime) {
+    public void validate() {
+        if (recommendedWorkId == null) {
+            throw new WorkException(NULL_RECOMMENDED_WORK_ID);
+        }
+        if (startTime == null){
+            throw new WorkException(NULL_START_TIME);
+        }
+        if (endTime == null){
+            throw new WorkException(NULL_END_TIME);
+        }
+    }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
@@ -6,8 +6,12 @@ public enum WorkResponseStatus {
     INVALID_MY_WORK_TIME(7003, "농작업 시간이 유효하지 않습니다."),
     MY_WORK_NOT_FOUND(7004, "해당 작업이 존재하지 않습니다."),
     MY_WORK_NOT_COMPLETED(7005, "해당 작업이 완료되지 않았습니다."),
-    LIFE_CYCLE_NOT_FOUND(7006, "일치하는 생육 단계가 존재하지 않습니다.")
-    ;
+    LIFE_CYCLE_NOT_FOUND(7006, "일치하는 생육 단계가 존재하지 않습니다."),
+    NULL_RECOMMENDED_WORK_ID(7006, "recommendedWorkId가 null입니다."),
+    NULL_MY_CROP_ID(7007, "myCropId가 null입니다."),
+    NULL_START_TIME(7008, "startTime이 null입니다."),
+    NULL_END_TIME(7009, "end이 null입니다."),
+    NULL_MY_WORK_ID(7010, "myWorkId가 null입니다.");
 
     private int code;
     private String message;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
@@ -10,7 +10,7 @@ public enum WorkResponseStatus {
     NULL_RECOMMENDED_WORK_ID(7006, "recommendedWorkId가 null입니다."),
     NULL_MY_CROP_ID(7007, "myCropId가 null입니다."),
     NULL_START_TIME(7008, "startTime이 null입니다."),
-    NULL_END_TIME(7009, "end이 null입니다."),
+    NULL_END_TIME(7009, "endTime이 null입니다."),
     NULL_MY_WORK_ID(7010, "myWorkId가 null입니다.");
 
     private int code;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #261 

---

## 📝작업 내용

1. `@Validated`를 사용하면서 request로 들어오는 필드가 null, blank일 경우 던져지는 반환 에러 code는 무조건 400이었습니다. 이를 세분화하고자 `@Validated`를 사용하지 않고 dto 내에 `validate()` 메서드를 구현했습니다. 

2. 에러 코드 명세를 [노션 페이지](https://www.notion.so/250e13d978228048878aeb9980dfcfa5?source=copy_link)에 작성했습니다.

---

## 💬리뷰 요구사항

필드 검증 용도 정도는... dto가 셀프로 메서드를 가지고 있어도 괜찮겠지요...?

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)