### PR TITLE
[Feat] 날씨 정보 페이지 - 자외선 및 일출몰 API 연동

### DIFF
--- a/frontend/src/apis/weather.api.ts
+++ b/frontend/src/apis/weather.api.ts
@@ -1,5 +1,14 @@
 import HTTP from './http';
-import { GetWeatherConditionResponse } from '@/types/openapiGenerator';
+import {
+  GetSunRiseSetTimeResponse,
+  GetUVInfoResponse,
+  GetWeatherConditionResponse,
+} from '@/types/openapiGenerator';
 
 export const getWeatherNow = () =>
   HTTP.get<GetWeatherConditionResponse>('/weather/now');
+
+export const getWeatherUV = () => HTTP.get<GetUVInfoResponse>('/weather/uv');
+
+export const getWeatherSunset = () =>
+  HTTP.get<GetSunRiseSetTimeResponse>('/weather/sunriseSet');

--- a/frontend/src/pages/weatherBoardPage/WeatherBoardPage.tsx
+++ b/frontend/src/pages/weatherBoardPage/WeatherBoardPage.tsx
@@ -83,9 +83,9 @@ const WeatherBoardPage = () => {
             ${S.WeatherBoardContent}
           `}
         >
-          <WeatherBoardUV value={8} startTime="08:00" endTime="18:00" />
+          <WeatherBoardUV />
           <WeatherBoardDust fineDustValue={55} ultrafineDustValue={78} />
-          <WeatherBoardSunset startTime="01:00" endTime="01:50" />
+          <WeatherBoardSunset />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardSunset/WeatherBoardSunset.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardSunset/WeatherBoardSunset.tsx
@@ -2,14 +2,13 @@ import { GrayScale } from '@/styles/colors';
 import S from './WeatherBoardSunset.style';
 import { SunEffect } from '@/assets/icons/flat';
 import { useSunsetAnimation } from '@/pages/weatherBoardPage/hooks/useSunsetAnimation';
+import { useEffect, useState } from 'react';
+import { getWeatherSunset } from '@/apis/weather.api';
+import { GetSunRiseSetTimeResponse } from '@/types/openapiGenerator';
 
-const WeatherBoardSunset = ({
-  startTime,
-  endTime,
-}: {
-  startTime: string;
-  endTime: string;
-}) => {
+const WeatherBoardSunset = () => {
+  const [sunsetData, setSunsetData] = useState<GetSunRiseSetTimeResponse>();
+
   const {
     progress,
     sunX,
@@ -20,7 +19,25 @@ const WeatherBoardSunset = ({
     clipId,
     viewBox,
     semicircleStrokePath,
-  } = useSunsetAnimation({ startTime, endTime });
+  } = useSunsetAnimation({
+    startTime: sunsetData?.startTime || '00:00',
+    endTime: sunsetData?.endTime || '00:00',
+  });
+
+  const fetchSunsetData = async () => {
+    try {
+      const res = await getWeatherSunset();
+      if (res.data) {
+        setSunsetData(res.data);
+      }
+    } catch (error) {
+      console.error('Error fetching sunset data:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchSunsetData();
+  }, []);
 
   return (
     <div css={S.WeatherBoardSunset}>
@@ -72,8 +89,8 @@ const WeatherBoardSunset = ({
       </div>
 
       <div css={S.WeatherBoardSunsetTimeWrapper}>
-        <span css={S.WeatherBoardSunsetTime}>{startTime}</span>
-        <span css={S.WeatherBoardSunsetTime}>{endTime}</span>
+        <span css={S.WeatherBoardSunsetTime}>{sunsetData?.startTime}</span>
+        <span css={S.WeatherBoardSunsetTime}>{sunsetData?.endTime}</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
@@ -4,15 +4,34 @@ import S from './WeatherBoardUV.style';
 import { FlexStyles } from '@/styles/commonStyles';
 import { Typography } from '@/styles/typography';
 import { GrayScale } from '@/styles/colors';
+import { getWeatherUV } from '@/apis/weather.api';
+import { useEffect, useState } from 'react';
+import { GetUVInfoResponse } from '@/types/openapiGenerator';
 
-interface WeatherBoardUVProps {
-  value: number;
-  startTime: string;
-  endTime: string;
-}
+// interface WeatherBoardUVProps {
+//   value: number;
+//   startTime: string;
+//   endTime: string;
+// }
 
-const WeatherBoardUV = ({ value, startTime, endTime }: WeatherBoardUVProps) => {
-  const { level, color } = getUVLevelAndColor(value);
+const WeatherBoardUV = () => {
+  const [uvData, setUVData] = useState<GetUVInfoResponse>();
+  const { level, color } = getUVLevelAndColor(uvData?.value || 0);
+
+  const fetchUVData = async () => {
+    try {
+      const res = await getWeatherUV();
+      if (res.data) {
+        setUVData(res.data);
+      }
+    } catch (error) {
+      console.error('Error fetching UV data:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchUVData();
+  }, []);
 
   return (
     <div css={S.WeatherBoardUV}>
@@ -24,7 +43,7 @@ const WeatherBoardUV = ({ value, startTime, endTime }: WeatherBoardUVProps) => {
             margin-bottom: 18px;
           `}
         >
-          <p>{value}</p>
+          <p>{uvData?.value}</p>
           <span css={Typography.Caption_S}>{level}</span>
         </div>
         <svg
@@ -64,8 +83,8 @@ const WeatherBoardUV = ({ value, startTime, endTime }: WeatherBoardUVProps) => {
         </svg>
 
         <div css={S.WeatherBoardUVTimeWrapper}>
-          <span css={S.WeatherBoardUVTime}>{startTime}</span>
-          <span css={S.WeatherBoardUVTime}>{endTime}</span>
+          <span css={S.WeatherBoardUVTime}>{uvData?.startTime}</span>
+          <span css={S.WeatherBoardUVTime}>{uvData?.endTime}</span>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
+++ b/frontend/src/pages/weatherBoardPage/components/weatherBoardUV/WeatherBoardUV.tsx
@@ -8,12 +8,6 @@ import { getWeatherUV } from '@/apis/weather.api';
 import { useEffect, useState } from 'react';
 import { GetUVInfoResponse } from '@/types/openapiGenerator';
 
-// interface WeatherBoardUVProps {
-//   value: number;
-//   startTime: string;
-//   endTime: string;
-// }
-
 const WeatherBoardUV = () => {
   const [uvData, setUVData] = useState<GetUVInfoResponse>();
   const { level, color } = getUVLevelAndColor(uvData?.value || 0);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #285 

---

## 📝작업 내용
- 자외선 및 일출몰 API 정의
- API 연동 및 데이터 적용
- 자외선, 일출몰 컴포넌트 props 제거


---

### 스크린샷 (선택)

https://github.com/user-attachments/assets/8de4073d-48d4-48c0-aa6c-8e6570c85a97


---

## 💬리뷰 요구사항

1. 그... 일단은 각각 컴포넌트의 useEffect 안에서 api를 호출하고 있는데 이게 좋은건지 아니면 부모에서 한번에 useEffect안에서 호출하고 props로 넘겨주는게 좋을지 모르겠슴다...
2. API response로 데이터가 불러와지기 전에 렌더링되면서 애니메이션이나 데이터 로딩이 안 되는 문제가 있습니다.. 이것도 나중에 고칠게요... 기록해두겠습니당...

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)