### PR TITLE
[Fix] 농작업 추천 목록 추천 시간대 로직 수정 

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/util/WorkScheduleCalculator.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/util/WorkScheduleCalculator.java
@@ -36,9 +36,7 @@ public class WorkScheduleCalculator {
         if (w.isLowTemperature() && lowT) return false;
         if (w.isHighHumidity() && highH) return false;
         if (w.isLowHumidity() && lowH) return false;
-        if (w.isStrongWind() && wind) return false;
-
-        return true;
+        return !w.isStrongWind() || !wind;
     }
 
     private List<RecommendWorksResponse.RecommendedWorksResponse> windowsForWork(RecommendedWork work,
@@ -131,8 +129,8 @@ public class WorkScheduleCalculator {
 
         LocalDateTime dt = LocalDateTime.of(from.toLocalDate(), LocalTime.of(hour, minute));
 
-        // 날짜 보정: 예측 시간이 요청 시각보다 작으면 다음날로 이동
-        if (dt.isBefore(from) && hour < from.getHour()) {
+
+        if (dt.isBefore(from)) {
             dt = dt.plusDays(1);
         }
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #295

---

## 📝작업 내용

페이지 접속 시간 기준 24시간 이내의 농작업일정을 등록할 수 있으므로 다음날 시간대로 명시되는 것은 문제가 아닌데 수상하게 일괄 0~6시로 추천되는 것을 확인했습니다.
의심하고 있었던 서버 TimeZone 설정은 서울 기준으로 잘 돼있는 것을 확인했습니다. 
일단 불필요한 로직을 삭제하고 서버 배포 후 다시 확인해보고자 합니다. 


---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)