### PR TITLE
[Feat] 기상 리스크가 존재하지 않는 경우, 시간대에 따른 메시지 반환

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
@@ -1,6 +1,7 @@
 package com.imsnacks.Nyeoreumnagi.weather.service;
 
 import com.imsnacks.Nyeoreumnagi.weather.entity.WeatherRisk;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
@@ -18,7 +19,12 @@ public final class Briefing {
     public static final String KST = "Asia/Seoul";
     public static final Comparator<WeatherRisk> RISK_COMPARATOR = new RiskComparator();
 
-    public static String buildMsg(final WeatherRisk risk) {
+    public static final String GOOD_MORNING = "오늘도 힘찬 하루 보내세요.";
+    public static final String GOOD_AFTERNOON = "점심은 맛있게 드셨나요?";
+    public static final String GOOD_EVENING = "오늘 하루도 수고 많으셨어요.";
+    public static final String GOOD_NIGHT = "편안한 시간 보내고 계신가요?";
+
+    public static String buildWeatherRiskMsg(final WeatherRisk risk) {
         assert(risk != null);
         final String from = getClockHourAsString(risk.getStartTime()); // <오전/오후> <1-12>시
         final String to = getClockHourAsString(risk.getEndTime());
@@ -29,6 +35,19 @@ public final class Briefing {
         sb.append(risk.getType().getDescription());
 
         return sb.toString();
+    }
+
+    public static @NotNull String buildGreetingMsg(final LocalDateTime time) {
+        final int hour = time.getHour();
+        if (hour < 6) {
+            return GOOD_NIGHT;
+        } else if (hour < 12) {
+            return GOOD_MORNING;
+        } else if (hour < 18) {
+            return GOOD_AFTERNOON;
+        } else {
+            return GOOD_EVENING;
+        }
     }
 
     private static String getClockHourAsString(final LocalDateTime time) {

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -16,6 +16,7 @@ import com.imsnacks.Nyeoreumnagi.weather.repository.WeatherRiskRepository;
 import com.imsnacks.Nyeoreumnagi.weather.service.projection_entity.SunriseSunSetTime;
 import com.imsnacks.Nyeoreumnagi.weather.service.projection_entity.UVInfo;
 import com.imsnacks.Nyeoreumnagi.weather.util.WeatherRiskIntervalMerger;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -105,7 +106,7 @@ public class WeatherService {
         return new GetWeatherConditionResponse(weatherCondition.toString(), weatherCondition.getKeyword(), temperature);
     }
 
-    public GetWeatherBriefingResponse getWeatherBriefing(final Long memberId) {
+    public GetWeatherBriefingResponse getWeatherBriefing(@NotNull final Long memberId) {
         assert(memberId != null);
         final Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
         final Farm farm = member.getFarm();
@@ -116,22 +117,23 @@ public class WeatherService {
         final int nx = farm.getNx();
         final int ny = farm.getNy();
 
+        final LocalDateTime now = LocalDateTime.now(ZoneId.of(Briefing.KST));
+
         final List<WeatherRisk> allRisks = weatherRiskRepository.findByNxAndNyWithMaxJobExecutionId(nx, ny);
         if (allRisks.isEmpty()) { // 기상 특이 사항이 없는 것이니 exception이 아닌 false 응답을 보낸다.
-            return new GetWeatherBriefingResponse(false, "");
+            return new GetWeatherBriefingResponse(false, Briefing.buildGreetingMsg(now));
         }
 
-        final LocalDateTime now = LocalDateTime.now(ZoneId.of(Briefing.KST));
         final List<WeatherRisk> filteredRisk = allRisks.stream()
                 .filter(r -> r.getEndTime().isAfter(now))
                 .sorted(Briefing.RISK_COMPARATOR) // 우선 순위가 가장 앞서는 것이 맨 앞에 오도록 정렬한다.
                 .toList();
         if (filteredRisk.isEmpty()) { // 기상 특이 사항이 없는 것이니 exception이 아닌 false 응답을 보낸다.
-            return new GetWeatherBriefingResponse(false, "");
+            return new GetWeatherBriefingResponse(false, Briefing.buildGreetingMsg(now));
         }
-        final String msg = Briefing.buildMsg(filteredRisk.get(0));
+        final String weatherRiskmsg = Briefing.buildWeatherRiskMsg(filteredRisk.get(0));
 
-        return new GetWeatherBriefingResponse(true, msg);
+        return new GetWeatherBriefingResponse(true, weatherRiskmsg);
     }
 
     public GetSunRiseSetTimeResponse getSunRiseSetTime(final Long memberId) {


### PR DESCRIPTION
## 📌 연관된 이슈

- close #266 

---

## 📝작업 내용

- 표시할 기상 상황이 없는 경우, 시간대에 따른 인사말을 반환한다.
    
    아침 (KST, UTC+9 06:00:00~11:59:59): (유저 아이디/닉네임)님! 오늘도 힘찬 하루 보내세요.
    
    오후 (KST, UTC+9 12:00:00~17:59:59): (유저 아이디/닉네임)님! 점심은 맛있게 드셨나요?
    
    저녁 (KST, UTC+9 18:00:00~23:59:59): (유저 아이디/닉네임)님! 오늘 하루도 수고 많으셨어요.
    
    밤 (KST, UTC+9 00:00:00~05:59:59): (유저 아이디/닉네임)님! 편안한 시간 보내고 계신가요?

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)