### PR TITLE
[Fix] SevenDayApiRequestValue에 toString() 추가

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/seven_days_weather_forecast/reader/SevenDayApiRequestValue.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/seven_days_weather_forecast/reader/SevenDayApiRequestValue.java
@@ -15,4 +15,9 @@ public enum SevenDayApiRequestValue {
     SevenDayApiRequestValue(String value) {
         this.value = value;
     }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #320

---

## 📝작업 내용

1. 7일 예보 배치 reader에서 URI를 정상 사용하지 못하는 오류를 해결하기 위해 SevenDayApiRequestValue에 toString() 를 추가했습니다.
- ApiRequestValue에 모아두던 값들을 SevenDayApiRequestValue 로 분리하는 과정에서 메서드를 빠뜨렸습니다.

---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)