### PR TITLE
[Fix] 유저 지번 주소 조회 API 반환 형식 수정

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/MemberService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/MemberService.java
@@ -17,11 +17,19 @@ public class MemberService {
 
     public GetMemberAddressResponse getMemberAddress(Long memberId){
         Farm farm = farmRepository.findByMember_Id(memberId).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+        String responseAddress = engraftAddress(farm);
+        return new GetMemberAddressResponse(responseAddress);
+    }
+
+    private String engraftAddress(Farm farm){
         StringBuilder builder = new StringBuilder();
         builder.append(farm.getState());
+        builder.append(" ");
         builder.append(farm.getCity());
+        builder.append(" ");
         builder.append(farm.getTown());
+        builder.append(" ");
         builder.append(farm.getAddress());
-        return new GetMemberAddressResponse(builder.toString());
+        return builder.toString();
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/MemberService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/MemberService.java
@@ -17,6 +17,11 @@ public class MemberService {
 
     public GetMemberAddressResponse getMemberAddress(Long memberId){
         Farm farm = farmRepository.findByMember_Id(memberId).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-        return new GetMemberAddressResponse(farm.getState(), farm.getCity(), farm.getTown(), farm.getAddress());
+        StringBuilder builder = new StringBuilder();
+        builder.append(farm.getState());
+        builder.append(farm.getCity());
+        builder.append(farm.getTown());
+        builder.append(farm.getAddress());
+        return new GetMemberAddressResponse(builder.toString());
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/dto/response/GetMemberAddressResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/dto/response/GetMemberAddressResponse.java
@@ -1,9 +1,6 @@
 package com.imsnacks.Nyeoreumnagi.member.dto.response;
 
 public record GetMemberAddressResponse(
-        String state,
-        String city,
-        String town,
         String address
 ) {
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/controller/WeatherController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/controller/WeatherController.java
@@ -120,7 +120,7 @@ public class WeatherController {
     @Operation(summary = "일일 시간별 기온 조회")
     @ApiResponse(responseCode = "200", description = "일일 시간별 기온 조회 성공")
     @ApiResponse(responseCode = "400", description = "일일 시간별 기온 조회 실패")
-    @GetMapping("/temperature")
+    @GetMapping("/temperatureInfo")
     public ResponseEntity<CustomResponseBody<GetTemperatureResponse>> getTemperature(@PreAuthorize Long memberId) {
         return ResponseUtil.success(weatherService.getTemperature(memberId));
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/dto/response/GetTemperatureResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/dto/response/GetTemperatureResponse.java
@@ -1,5 +1,7 @@
 package com.imsnacks.Nyeoreumnagi.weather.dto.response;
 
+import com.imsnacks.Nyeoreumnagi.weather.entity.DashboardWeatherForecast;
+
 import java.util.List;
 
 public record GetTemperatureResponse(
@@ -12,5 +14,9 @@ public record GetTemperatureResponse(
             String weatherType,
             Integer value
     ){
+        public static TemperaturePerTime from(DashboardWeatherForecast dashboardWeatherForecast) {
+            String time = String.format("%02d:00", dashboardWeatherForecast.getFcstTime());
+            return new TemperaturePerTime(time, dashboardWeatherForecast.getWeatherCondition().toString(), dashboardWeatherForecast.getTemperature());
+        }
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecast.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecast.java
@@ -3,11 +3,13 @@ package com.imsnacks.Nyeoreumnagi.weather.entity;
 import com.imsnacks.Nyeoreumnagi.common.enums.WeatherCondition;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 @IdClass(DashboardWeatherForecastId.class)
 public class DashboardWeatherForecast {
     @Id

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecast.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecast.java
@@ -1,0 +1,27 @@
+package com.imsnacks.Nyeoreumnagi.weather.entity;
+
+import com.imsnacks.Nyeoreumnagi.common.enums.WeatherCondition;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@IdClass(DashboardWeatherForecastId.class)
+public class DashboardWeatherForecast {
+    @Id
+    private int nx;
+    @Id
+    private int ny;
+    @Id
+    @Column(name = "fcst_time")
+    private int fcstTime;
+
+    @Column(name = "temperature", nullable = false)
+    Integer temperature;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sky_status", nullable = false)
+    WeatherCondition weatherCondition;
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecastId.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/DashboardWeatherForecastId.java
@@ -1,0 +1,16 @@
+package com.imsnacks.Nyeoreumnagi.weather.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class DashboardWeatherForecastId implements Serializable {
+    private int nx;
+    private int ny;
+    private int fcstTime;
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/exception/WeatherResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/exception/WeatherResponseStatus.java
@@ -10,7 +10,8 @@ public enum WeatherResponseStatus {
     NO_WIND_INFO(3007, "해당 지역 풍속/풍향 정보가 없습니다."),
     NO_HUMIDITY_INFO(3008, "해당 지역 습도 정보가 없습니다."),
     NO_PRECIPITATION(3009, "해당 지역 강수량 정보가 없습니다."),
-    INVALID_SEVEN_DAY_FORECAST_COUNT(3010, "7일 예보 결과는 7개여야 합니다.")
+    INVALID_SEVEN_DAY_FORECAST_COUNT(3010, "7일 예보 결과는 7개여야 합니다."),
+    NO_TEMPERATURE_INFO(3011, "해당 지역 기온 정보가 없습니다."),
     ;
 
     private final int code;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/repository/DashboardWeatherForecastRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/repository/DashboardWeatherForecastRepository.java
@@ -5,6 +5,9 @@ import com.imsnacks.Nyeoreumnagi.weather.entity.DashboardWeatherForecastId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DashboardWeatherForecastRepository extends JpaRepository<DashboardWeatherForecast, DashboardWeatherForecastId> {
+    List<DashboardWeatherForecast> findByNxAndNy(int nx, int ny);
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/repository/DashboardWeatherForecastRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/repository/DashboardWeatherForecastRepository.java
@@ -1,0 +1,10 @@
+package com.imsnacks.Nyeoreumnagi.weather.repository;
+
+import com.imsnacks.Nyeoreumnagi.weather.entity.DashboardWeatherForecast;
+import com.imsnacks.Nyeoreumnagi.weather.entity.DashboardWeatherForecastId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DashboardWeatherForecastRepository extends JpaRepository<DashboardWeatherForecast, DashboardWeatherForecastId> {
+}

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/member/MemberServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/member/MemberServiceTest.java
@@ -39,10 +39,7 @@ class MemberServiceTest {
         GetMemberAddressResponse response = memberService.getMemberAddress(memberId);
 
         // then
-        assertThat(response.state()).isEqualTo("경기도");
-        assertThat(response.city()).isEqualTo("성남시");
-        assertThat(response.town()).isEqualTo("분당구");
-        assertThat(response.address()).isEqualTo("정자1동 123-45");
+        assertThat(response.address()).isEqualTo("경기도 성남시 분당구 정자1동 123-45");
     }
 
     @Test

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherServiceTest.java
@@ -7,9 +7,11 @@ import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
 import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
 import com.imsnacks.Nyeoreumnagi.weather.dto.response.*;
+import com.imsnacks.Nyeoreumnagi.weather.entity.DashboardWeatherForecast;
 import com.imsnacks.Nyeoreumnagi.weather.entity.ShortTermWeatherForecast;
 import com.imsnacks.Nyeoreumnagi.weather.exception.WeatherException;
 import com.imsnacks.Nyeoreumnagi.weather.repository.DashboardTodayWeatherRepository;
+import com.imsnacks.Nyeoreumnagi.weather.repository.DashboardWeatherForecastRepository;
 import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
 import com.imsnacks.Nyeoreumnagi.weather.repository.WeatherRiskRepository;
 import com.imsnacks.Nyeoreumnagi.weather.service.WeatherService;
@@ -27,6 +29,7 @@ import org.mockito.quality.Strictness;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -56,6 +59,8 @@ class WeatherServiceTest {
     private WeatherRiskRepository weatherRiskRepository;
     @Mock
     private DashboardTodayWeatherRepository dashboardTodayWeatherRepository;
+    @Mock
+    private DashboardWeatherForecastRepository dashboardWeatherForecastRepository;
 
     @Test
     void getWeatherGraph_성공() {
@@ -331,5 +336,73 @@ class WeatherServiceTest {
 
         // then
         assertThat(response.value()).isEqualTo(12);
+    }
+
+    @Test
+    void 시간별_기온_조회_성공() {
+        //given
+        Long memberId = 1L;
+        Farm fakeFarm = mock(Farm.class);
+        when(fakeFarm.getNx()).thenReturn(60);
+        when(fakeFarm.getNy()).thenReturn(127);
+
+        when(farmRepository.findByMember_Id(memberId)).thenReturn(Optional.of(fakeFarm));
+
+        List<DashboardWeatherForecast> forecasts = new ArrayList<>();
+        int[] times = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+        int[] temps = {1,14,1,1,15,1,1,16,1,1,17,1,1,12,1,1,18,1,1,11,1,1,13};
+
+        for (int i=0; i<23; ++i) {
+            DashboardWeatherForecast f = mock(DashboardWeatherForecast.class);
+            when(f.getFcstTime()).thenReturn(times[i]);
+            when(f.getTemperature()).thenReturn(temps[i]);
+            when(f.getWeatherCondition()).thenReturn(WeatherCondition.SUNNY);
+            forecasts.add(f);
+        }
+
+        when(dashboardWeatherForecastRepository.findByNxAndNy(60,127))
+                .thenReturn(forecasts);
+
+        //when
+        GetTemperatureResponse response = weatherService.getTemperature(memberId);
+
+        //then
+        assertThat(response.maxTemperature()).isEqualTo(18);
+        assertThat(response.minTemperature()).isEqualTo(11);
+        assertThat(response.temperaturePerTime().stream().map(GetTemperatureResponse.TemperaturePerTime::time).toList())
+                .isEqualTo(List.of("02:00","05:00","08:00","11:00","14:00","17:00","20:00","23:00"));
+        assertThat(response.temperaturePerTime().stream().map(GetTemperatureResponse.TemperaturePerTime::value).toList())
+                .isEqualTo(List.of(14,15,16,17,12,18,11,13));
+    }
+
+    @Test
+    void 시간별_기온_조회시_3시간_간격에_해당하는_시간이_없을_때_예외처리() {
+        //given
+        Long memberId = 1L;
+        Farm fakeFarm = mock(Farm.class);
+        when(fakeFarm.getNx()).thenReturn(60);
+        when(fakeFarm.getNy()).thenReturn(127);
+
+        when(farmRepository.findByMember_Id(memberId)).thenReturn(Optional.of(fakeFarm));
+
+        List<DashboardWeatherForecast> forecasts = new ArrayList<>();
+        int[] times = {1,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+        int[] temps = {1,1,1,15,1,1,16,1,1,17,1,1,12,1,1,18,1,1,11,1,1,13};
+
+        for (int i=0; i<22; ++i) {
+            DashboardWeatherForecast f = mock(DashboardWeatherForecast.class);
+            when(f.getFcstTime()).thenReturn(times[i]);
+            when(f.getTemperature()).thenReturn(temps[i]);
+            when(f.getWeatherCondition()).thenReturn(WeatherCondition.SUNNY);
+            forecasts.add(f);
+        }
+
+        when(dashboardWeatherForecastRepository.findByNxAndNy(60,127))
+                .thenReturn(forecasts);
+
+        //when
+        //then
+        assertThatThrownBy(() -> weatherService.getTemperature(memberId))
+                .isInstanceOf(WeatherException.class);
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #330 

---

## 📝작업 내용

기존 유저 지번 주소 조회 API 응답 형식을 수정해 달라는 요청이 있어 반영했습니다. 

기존
```json
{
  "code": 200,
  "msg": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "state": "Gyeonggi",
    "city": "Suwon",
    "town": "Yeongtong-gu",
    "address": "123 Suwon Street"
  }
}
```

요청 형식
```json
{
  "code": 200,
  "msg": "요청이 성공적으로 처리되었습니다.",
  "data": {
    "address": "Gyeonggi Suwon Yeongtong-gu 123 Suwon Street"
  }
}
```
---


## 💬리뷰 요구사항

없습니다. 😁

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)