### PR TITLE
[Feat] 내 농작업 상태 변경 기능

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/entity/Member.java
@@ -36,6 +36,6 @@ public class Member {
     @Setter
     private UUID refreshToken;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     Farm farm;
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
@@ -6,6 +6,7 @@ import com.imsnacks.Nyeoreumnagi.common.auth.annotation.PreAuthorize;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.DeleteMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.ModifyMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.RegisterMyWorkRequest;
+import com.imsnacks.Nyeoreumnagi.work.dto.request.UpdateMyWorkStatusRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.GetMyWorksOfTodayResponse;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.GetMyWorksOfWeeklyResponse;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.ModifyMyWorkResponse;
@@ -58,7 +59,7 @@ public class MyWorkController {
     @Operation(summary = "농작업 수정")
     @ApiResponse(responseCode = "200", description = "농작업 수정 성공")
     @ApiResponse(responseCode = "400", description = "농작업 수정 실패")
-    @PatchMapping("")
+    @PatchMapping("/time")
     public ResponseEntity<CustomResponseBody<ModifyMyWorkResponse>> modifyMyWork(@RequestBody ModifyMyWorkRequest request, @PreAuthorize Long memberId) {
         request.validate();
         ModifyMyWorkResponse modifyMyWorkResponse = myWorkService.modifyMyWork(request, memberId);
@@ -86,5 +87,16 @@ public class MyWorkController {
     public ResponseEntity<CustomResponseBody<List<GetMyWorksOfWeeklyResponse>>> getMyWorksOfWeek(@RequestParam String startDate, @PreAuthorize Long memberId) {
         List<GetMyWorksOfWeeklyResponse> myWorksOfWeekly = myWorkService.getMyWorksOfWeekly(startDate, memberId);
         return ResponseUtil.success(myWorksOfWeekly);
+    }
+
+    @SecurityRequirement(name = "BearerAuth")
+    @Operation(summary = "내 농작업 상태 변경")
+    @ApiResponse(responseCode = "200", description = "내 농작업 상태 변경 성공")
+    @ApiResponse(responseCode = "400", description = "내 농작업 상태 변경 실패")
+    @PatchMapping("/status")
+    public ResponseEntity<CustomResponseBody<List<GetMyWorksOfTodayResponse>>> updateMyWorkStatus(@RequestBody UpdateMyWorkStatusRequest request, @PreAuthorize Long memberId) {
+        request.validate();
+        myWorkService.updateMyWorkStatus(request, memberId);
+        return ResponseUtil.success();
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/UpdateMyWorkStatusRequest.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/dto/request/UpdateMyWorkStatusRequest.java
@@ -1,0 +1,21 @@
+package com.imsnacks.Nyeoreumnagi.work.dto.request;
+
+import com.imsnacks.Nyeoreumnagi.work.entity.WorkStatus;
+import com.imsnacks.Nyeoreumnagi.work.exception.WorkException;
+
+import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.NULL_MY_CROP_ID;
+import static com.imsnacks.Nyeoreumnagi.work.exception.WorkResponseStatus.NULL_WORK_STATUS;
+
+public record UpdateMyWorkStatusRequest(
+        Long myWorkId,
+        WorkStatus status
+) {
+    public void validate(){
+        if(myWorkId == null){
+            throw new WorkException(NULL_MY_CROP_ID);
+        }
+        if(status == null){
+            throw new WorkException(NULL_WORK_STATUS);
+        }
+    }
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/entity/MyWork.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/entity/MyWork.java
@@ -17,10 +17,10 @@ public class MyWork {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     private RecommendedWork recommendedWork;
 
     @Column(name = "start_time", nullable = false)

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/WorkResponseStatus.java
@@ -13,7 +13,8 @@ public enum WorkResponseStatus {
     NULL_MY_WORK_ID(7010, "myWorkId가 null입니다."),
     START_TIME_IS_FUTURE(7011, "요청 시작 시간이 미래입니다."),
     NULL_RECOMMENDED_WORK_ID(7012, "recommendedWorkId가 null입니다."),
-    INVALID_START_TIME_FORMAT(7013, "요청 startTime 형식은 'yyyy-MM-dd'이어야 합니다.")
+    INVALID_START_TIME_FORMAT(7013, "요청 startTime 형식은 'yyyy-MM-dd'이어야 합니다."),
+    NULL_WORK_STATUS(7014, "작업 상태가 null입니다.")
     ;
 
     private int code;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyWorkRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyWorkRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MyWorkRepository extends JpaRepository<MyWork, Long> {
     List<MyWork> findByMember_IdAndStartTimeAfter(Long memberId, LocalDateTime startTimeAfter);
 
     List<MyWork> findByMember_IdAndStartTimeBetween(Long memberId, LocalDateTime startTimeAfter, LocalDateTime startTimeBefore);
+
+    Optional<MyWork> findByIdAndMember_Id(Long id, Long memberId);
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
@@ -6,6 +6,7 @@ import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.DeleteMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.ModifyMyWorkRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.request.RegisterMyWorkRequest;
+import com.imsnacks.Nyeoreumnagi.work.dto.request.UpdateMyWorkStatusRequest;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.GetMyWorksOfTodayResponse;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.GetMyWorksOfWeeklyResponse;
 import com.imsnacks.Nyeoreumnagi.work.dto.response.ModifyMyWorkResponse;
@@ -112,7 +113,7 @@ public class MyWorkService {
                 )
         );
 
-        if(isMobile){
+        if (isMobile) {
             return responseStream.sorted(Comparator
                             .comparing(GetMyWorksOfTodayResponse::status, (s1, s2) -> {
                                 if (s1.equals(INCOMPLETED) && s2.equals(COMPLETED)) {
@@ -140,7 +141,7 @@ public class MyWorkService {
         } catch (DateTimeParseException e) {
             throw new WorkException(INVALID_START_TIME_FORMAT);
         }
-        if (startDate.isAfter(LocalDate.now())){
+        if (startDate.isAfter(LocalDate.now())) {
             throw new WorkException(START_TIME_IS_FUTURE);
         }
         List<GetMyWorksOfWeeklyResponse> responseList = new ArrayList<>();
@@ -149,7 +150,7 @@ public class MyWorkService {
                 .stream().collect(Collectors.groupingBy(work -> work.getStartTime().toLocalDate(),
                         TreeMap::new,
                         Collectors.toList()
-                        ));
+                ));
 
         workDataMap.forEach((key, value) -> responseList.add(
                 new GetMyWorksOfWeeklyResponse(
@@ -165,5 +166,11 @@ public class MyWorkService {
         ));
 
         return responseList;
-}
+    }
+
+    @Transactional
+    public void updateMyWorkStatus(UpdateMyWorkStatusRequest request, long memberId){
+        MyWork myWork = myWorkRepository.findByIdAndMember_Id(request.myWorkId(), memberId).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
+        myWork.setWorkStatus(request.status());
+    }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #328 

---

## 📝작업 내용

1. 내 농작업 상태 변경 기능을 구현했습니다.
- 번호에 해당하는 농작업이 없거나 있는데 내 농작업이 아닐 경우 `NULL_WORK_STATUS` 에러를 반환합니다.

2. 농작업 상태 변경과 시간 변경을 구분하기 위해 기존에 `/myWork` 였던 농작업 시간 변경 기능의 엔드포인트를 `/myWork/time` 으로 변경하고 농작업 상태 변경의 엔드포인트는 `/myWork/status` 로 지정했습니다.

3. 농작업 상태 변경 시 아래와 같이 불필요하게 RecommendedWork와 Farm 의 select 쿼리가 날아가는 문제가 있었습니다.

### 개선 전
```SQL
[Hibernate] 
    select
        mw1_0.id,
        mw1_0.crop_name,
        mw1_0.end_time,
        mw1_0.member_id,
        mw1_0.recommended_work_id,
        mw1_0.start_time,
        mw1_0.work_status 
    from
        my_work mw1_0 
    left join
        member m1_0 
            on m1_0.id=mw1_0.member_id 
    where
        mw1_0.id=? 
        and m1_0.id=?
[Hibernate] 
    select
        m1_0.id,
        f1_0.id,
        f1_0.address,
        f1_0.city,
        f1_0.latitude,
        f1_0.longitude,
        f1_0.member_id,
        f1_0.mid_temp_region_code,
        f1_0.nx,
        f1_0.ny,
        f1_0.state,
        f1_0.town,
        m1_0.identifier,
        m1_0.nickname,
        m1_0.password,
        m1_0.phone_number,
        m1_0.refresh_token 
    from
        member m1_0 
    left join
        farm f1_0 
            on f1_0.id=m1_0.farm_id 
    where
        m1_0.id=?
[Hibernate] 
    select
        rw1_0.id,
        rw1_0.high_humidity,
        rw1_0.high_temperature,
        rw1_0.low_humidity,
        rw1_0.low_temperature,
        rw1_0.name,
        rw1_0.rain,
        rw1_0.recommendation,
        rw1_0.snow,
        rw1_0.strong_wind 
    from
        recommended_work rw1_0 
    where
        rw1_0.id=?

```

이를 개선하기 위해 `Member`에서 `Farm`을, `MyWork`에서 `RecommendedWork`를 lazy loading 하도록 설정했습니다.

### 개선 후

```SQL
[Hibernate] 
    select
        mw1_0.id,
        mw1_0.crop_name,
        mw1_0.end_time,
        mw1_0.member_id,
        mw1_0.recommended_work_id,
        mw1_0.start_time,
        mw1_0.work_status 
    from
        my_work mw1_0 
    left join
        member m1_0 
            on m1_0.id=mw1_0.member_id 
    where
        mw1_0.id=? 
        and m1_0.id=?
```


---

## 💬리뷰 요구사항

1. Member에서 Farm을 lazy loading하는 것은 `findByMember_Id` JPA 쿼리 메서드를 사용하고 있기 때문에 다른 기능에서도 문제가 없으나 `MyWork`에서 `RecommendedWork` 는 농작업 목록을 조회할 때마다 필요하기 때문에 이 기능에서 쿼리 횟수를 늘리더라도 eager loading 하는게 옳은 것 같기도 합니다. 아니면 나중에 lazy loading으로 세팅하고 필요 시 fetch join을 하는 방법도 있을 것 같습니다. 고민이네효~~

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)