### PR TITLE
[Feat] myCropId에 대한 병해충 피해 목록 생성 기능

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/dto/response/GetPestCardListResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/dto/response/GetPestCardListResponse.java
@@ -10,7 +10,8 @@ public record GetPestCardListResponse(
             long pestRiskId,
             String name,
             String description
-    ) {}
+    ) {
+    }
     public record MyCropCard(
             long myCropId,
             String myCropName

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/dto/response/GetPestCardListResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/dto/response/GetPestCardListResponse.java
@@ -1,0 +1,18 @@
+package com.imsnacks.Nyeoreumnagi.pest.dto.response;
+
+import java.util.List;
+
+public record GetPestCardListResponse(
+        List<PestCard> pestRisks,
+        List<MyCropCard> myCrops
+) {
+    public record PestCard(
+            long pestRiskId,
+            String name,
+            String description
+    ) {}
+    public record MyCropCard(
+            long myCropId,
+            String myCropName
+    ) {}
+}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/entity/PestRisk.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/entity/PestRisk.java
@@ -1,5 +1,6 @@
 package com.imsnacks.Nyeoreumnagi.pest.entity;
 
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.PestCard;
 import com.imsnacks.Nyeoreumnagi.work.entity.Crop;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -34,6 +35,9 @@ public class PestRisk {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name="description", nullable = false)
+    private String description;
+
     @Builder.Default
     @OneToMany(mappedBy = "pestRisk", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PestCondition> conditions = new ArrayList<>();
@@ -49,5 +53,9 @@ public class PestRisk {
 
     public void assignCrop(Crop crop) {
         this.crop = crop;
+    }
+
+    public PestCard toCard() {
+        return new PestCard(pestRiskId, name, description);
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
@@ -5,11 +5,10 @@ import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
 import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
 import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.MyCropCard;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.PestCard;
 import com.imsnacks.Nyeoreumnagi.pest.entity.PestCondition;
 import com.imsnacks.Nyeoreumnagi.pest.entity.PestRisk;
-import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.PestCard;
-import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.MyCropCard;
-
 import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.HumidityLevel;
 import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.RainLevel;
 import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.TemperatureLevel;
@@ -28,8 +27,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
@@ -42,24 +41,55 @@ public class PestService {
 
     public GetPestCardListResponse getPestCardList(final Long memberId, @Nullable final Long myCropId) {
         final Farm farm = farmRepo.findByMember_Id(memberId).orElseThrow(() -> new MemberException(MemberResponseStatus.NO_FARM_INFO));
-        final var forecastList = fcstRepo.findAllByNxAndNy(farm.getNx(), farm.getNy());
-        if (forecastList.isEmpty()) {
-            throw new WeatherException(WeatherResponseStatus.NO_WEATHER_LOCATION);
-        }
-        final WeatherConditionCode currentWeather = WeatherConditionCode.of(forecastList);
-        final LocalDateTime now = LocalDateTime.now();
+        final Crop target = (myCropId == null) ? findDefaultCrop(memberId) : findCropBy(myCropId);
+        final List<PestCard> pestCards = getPestCardsFor(target, farm.getNx(), farm.getNy());
+        final List<MyCropCard> myCropCards = (myCropId == null) ? getMyCropCards(memberId) : new ArrayList<>();
 
+        return new GetPestCardListResponse(pestCards, myCropCards);
+    }
+
+    private List<MyCropCard> getMyCropCards(long memberId) {
+        List<MyCrop> myCrops = this.myCropRepo.findAllByMember_IdOrderById(memberId);
+        return myCrops.stream()
+                .map(x -> new MyCropCard(x.getId(), x.getCrop().getName()))
+                .toList();
+    }
+
+    private Crop findDefaultCrop(long memberId) {
+        List<MyCrop> myCrops = myCropRepo.findAllByMember_IdOrderByCrop_Id(memberId);
+        if (myCrops.isEmpty()) {
+            //TODO 빈 리스트를 보내야 할까, 아니면 예외를 던져야 할까?
+            throw new CropException(CropResponseStatus.MY_CROP_NOT_FOUND);
+        }
+        Crop crop = myCrops.get(0).getCrop();
+        if (crop == null) {
+            throw new CropException(CropResponseStatus.MY_CROP_NOT_FOUND);
+        }
+        return crop;
+    }
+
+    private Crop findCropBy(@NotNull long myCropId) {
         final MyCrop myCrop = myCropRepo.findById(myCropId).orElseThrow(() -> new CropException(CropResponseStatus.MY_CROP_NOT_FOUND));
         final Crop crop = myCrop.getCrop();
         if (crop == null) {
             throw new CropException(CropResponseStatus.MY_CROP_NOT_FOUND);
         }
-        final List<PestRisk> relatedRisks = crop.getPestRisks();
-        final Stream<PestRisk> filtered = relatedRisks.stream()
-                .filter(x -> meetsCondition(x.getConditions(), currentWeather, now));
-        final List<PestCard> pestCards = filtered.map(x -> x.toCard()).limit(MAX_PEST_CARD_LIST_SIZE).toList();
+        return crop;
+    }
 
-        return new GetPestCardListResponse(pestCards, null);
+    private List<PestCard> getPestCardsFor(Crop target, int nx, int ny) {
+        List<ShortTermWeatherForecast> forecastList = fcstRepo.findAllByNxAndNy(nx, ny);
+        if (forecastList.isEmpty()) {
+            throw new WeatherException(WeatherResponseStatus.NO_WEATHER_LOCATION);
+        }
+        WeatherConditionCode forecast = WeatherConditionCode.of(forecastList);
+        LocalDateTime now = LocalDateTime.now();
+        List<PestRisk> relatedPests = target.getPestRisks();
+        return relatedPests.stream()
+                .filter(x -> meetsCondition(x.getConditions(), forecast, now))
+                .limit(MAX_PEST_CARD_LIST_SIZE)
+                .map(x -> x.toCard())
+                .toList();
     }
 
     private boolean meetsCondition(final List<PestCondition> pestConditions, final WeatherConditionCode weatherConditionCode, final LocalDateTime now) {

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
@@ -1,21 +1,123 @@
 package com.imsnacks.Nyeoreumnagi.pest.service;
 
+import com.imsnacks.Nyeoreumnagi.member.entity.Farm;
+import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
+import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
+import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse;
+import com.imsnacks.Nyeoreumnagi.pest.entity.PestCondition;
+import com.imsnacks.Nyeoreumnagi.pest.entity.PestRisk;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.PestCard;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse.MyCropCard;
+
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.HumidityLevel;
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.RainLevel;
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.TemperatureLevel;
 import com.imsnacks.Nyeoreumnagi.weather.entity.ShortTermWeatherForecast;
 import com.imsnacks.Nyeoreumnagi.weather.exception.WeatherException;
 import com.imsnacks.Nyeoreumnagi.weather.exception.WeatherResponseStatus;
 import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
+import com.imsnacks.Nyeoreumnagi.work.entity.Crop;
+import com.imsnacks.Nyeoreumnagi.work.entity.MyCrop;
+import com.imsnacks.Nyeoreumnagi.work.exception.CropException;
+import com.imsnacks.Nyeoreumnagi.work.exception.CropResponseStatus;
+import com.imsnacks.Nyeoreumnagi.work.repository.MyCropRepository;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
 public class PestService {
+    private final FarmRepository farmRepo;
     private final ShortTermWeatherForecastRepository fcstRepo;
+    private final MyCropRepository myCropRepo;
 
-    public
+    private static final int MAX_PEST_CARD_LIST_SIZE = 6;
+
+    public GetPestCardListResponse getPestCardList(final Long memberId, @Nullable final Long myCropId) {
+        final Farm farm = farmRepo.findByMember_Id(memberId).orElseThrow(() -> new MemberException(MemberResponseStatus.NO_FARM_INFO));
+        final var forecastList = fcstRepo.findAllByNxAndNy(farm.getNx(), farm.getNy());
+        if (forecastList.isEmpty()) {
+            throw new WeatherException(WeatherResponseStatus.NO_WEATHER_LOCATION);
+        }
+        final WeatherConditionCode currentWeather = WeatherConditionCode.of(forecastList);
+        final LocalDateTime now = LocalDateTime.now();
+
+        final MyCrop myCrop = myCropRepo.findById(myCropId).orElseThrow(() -> new CropException(CropResponseStatus.MY_CROP_NOT_FOUND));
+        final Crop crop = myCrop.getCrop();
+        if (crop == null) {
+            throw new CropException(CropResponseStatus.MY_CROP_NOT_FOUND);
+        }
+        final List<PestRisk> relatedRisks = crop.getPestRisks();
+        final Stream<PestRisk> filtered = relatedRisks.stream()
+                .filter(x -> meetsCondition(x.getConditions(), currentWeather, now));
+        final List<PestCard> pestCards = filtered.map(x -> x.toCard()).limit(MAX_PEST_CARD_LIST_SIZE).toList();
+
+        return new GetPestCardListResponse(pestCards, null);
+    }
+
+    private boolean meetsCondition(final List<PestCondition> pestConditions, final WeatherConditionCode weatherConditionCode, final LocalDateTime now) {
+        for (var condition : pestConditions) {
+            if (meetsTimeCondition(condition, now) && meetsWeatherCondition(condition, weatherConditionCode))
+                return true;
+        }
+        return false;
+    }
+
+    private boolean meetsTimeCondition(PestCondition condition, LocalDateTime now) {
+        int nowMonth = now.getMonth().getValue();
+        int nowDayOfMonth = now.getDayOfMonth();
+
+        int startMonth = condition.getStartMonth().getValue();
+        int startDayOfMonth = getDayOfMonthFromStartPhase(condition.getStartMonthPhase());
+        int endMonth = condition.getEndMonth().getValue();
+        int endDayOfMonth = getDayOfMonthFromEndPhase(condition.getEndMonthPhase());
+
+        boolean meetsStart = (startMonth == nowMonth && startDayOfMonth <= nowDayOfMonth) || (startMonth < nowMonth);
+        boolean meetsEnd = (endMonth == nowMonth && nowDayOfMonth <= endDayOfMonth) || (endMonth > nowMonth);
+
+        return meetsStart && meetsEnd;
+    }
+
+    private boolean meetsWeatherCondition(PestCondition condition, WeatherConditionCode currentWeather) {
+        return meetsHumidityCondition(condition.getHumidityLevel(), currentWeather.humidityLevel())
+                && meetsTemperatureCondition(condition.getTemperatureLevel(), currentWeather.temperatureLevel())
+                && meetsRainCondition(condition.getRainLevel(), currentWeather.rainLevel());
+    }
+
+    private boolean meetsHumidityCondition(HumidityLevel condition, HumidityLevel current) {
+        return (condition == HumidityLevel.DONT_CARE || condition == current);
+    }
+
+    private boolean meetsTemperatureCondition(TemperatureLevel condition, TemperatureLevel current) {
+        return (condition == TemperatureLevel.DONT_CARE || condition == current);
+    }
+
+    private boolean meetsRainCondition(RainLevel condition, RainLevel current) {
+        return (condition == RainLevel.DONT_CARE || condition == current);
+    }
+
+    private int getDayOfMonthFromStartPhase(PestCondition.MonthPhase phase) {
+        return switch (phase) {
+            case EARLY -> 1;
+            case MID -> 10;
+            case LATE -> 20;
+        };
+    }
+
+    private int getDayOfMonthFromEndPhase(PestCondition.MonthPhase phase) {
+        return switch (phase) {
+            case EARLY -> 10;
+            case MID -> 20;
+            case LATE -> 31;
+        };
+    }
 
     @NotNull
     private List<ShortTermWeatherForecast> getForecastList(final int nx, final int ny) {

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
@@ -61,7 +61,7 @@ public class PestService {
     }
 
     private List<MyCropCard> getMyCropCards(long memberId) {
-        List<MyCrop> myCrops = this.myCropRepo.findAllByMember_IdOrderById(memberId);
+        List<MyCrop> myCrops = myCropRepo.findAllByMember_IdOrderById(memberId);
         return myCrops.stream()
                 .map(x -> new MyCropCard(x.getId(), x.getCrop().getName()))
                 .toList();

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/pest/service/PestService.java
@@ -15,6 +15,8 @@ import java.util.List;
 public class PestService {
     private final ShortTermWeatherForecastRepository fcstRepo;
 
+    public
+
     @NotNull
     private List<ShortTermWeatherForecast> getForecastList(final int nx, final int ny) {
         List<ShortTermWeatherForecast> ret = fcstRepo.findAllByNxAndNy(nx, ny);

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface MyCropRepository extends JpaRepository<MyCrop, Long> {
     List<MyCrop> findAllByOrderByCrop_Id();
     List<MyCrop> findAllByMember_IdOrderByCrop_Id(long memberId);
+    List<MyCrop> findAllByMember_IdOrderByIdAsc(long memberId);
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface MyCropRepository extends JpaRepository<MyCrop, Long> {
     List<MyCrop> findAllByOrderByCrop_Id();
     List<MyCrop> findAllByMember_IdOrderByCrop_Id(long memberId);
-    List<MyCrop> findAllByMember_IdOrderByIdAsc(long memberId);
+    List<MyCrop> findAllByMember_IdOrderById(long memberId);
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/MyCropRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface MyCropRepository extends JpaRepository<MyCrop, Long> {
     List<MyCrop> findAllByOrderByCrop_Id();
+    List<MyCrop> findAllByMember_IdOrderByCrop_Id(long memberId);
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
@@ -5,7 +5,16 @@ import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
 import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
+import com.imsnacks.Nyeoreumnagi.pest.dto.response.GetPestCardListResponse;
+import com.imsnacks.Nyeoreumnagi.pest.entity.PestCondition;
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.HumidityLevel;
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.RainLevel;
+import com.imsnacks.Nyeoreumnagi.pest.service.WeatherConditionCode.TemperatureLevel;
+import com.imsnacks.Nyeoreumnagi.pest.entity.PestRisk;
+import com.imsnacks.Nyeoreumnagi.weather.entity.ShortTermWeatherForecast;
 import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
+import com.imsnacks.Nyeoreumnagi.work.entity.Crop;
+import com.imsnacks.Nyeoreumnagi.work.entity.MyCrop;
 import com.imsnacks.Nyeoreumnagi.work.repository.MyCropRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +25,10 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +37,17 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
 public class PestServiceTest {
+    private final int 저온 = WeatherConditionCode.TemperatureLevel.LevelBoundary.LOW_TO_MID.getThresholdValue() - 1;
+    private final int 보통기온 = WeatherConditionCode.TemperatureLevel.LevelBoundary.LOW_TO_MID.getThresholdValue();
+    private final int 고온 = WeatherConditionCode.TemperatureLevel.LevelBoundary.MID_TO_HIGH.getThresholdValue();
+
+    private final int 건조 = WeatherConditionCode.HumidityLevel.LevelBoundary.LOW_TO_MID.getThresholdValue() - 1;
+    private final int 보통습도 = WeatherConditionCode.HumidityLevel.LevelBoundary.LOW_TO_MID.getThresholdValue();
+    private final int 다습 = WeatherConditionCode.HumidityLevel.LevelBoundary.MID_TO_HIGH.getThresholdValue();
+
+    private final double 비없음 = WeatherConditionCode.RainLevel.LevelBoundary.RAIN.getThresholdValue() - 0.42;
+    private final double 비있음 = WeatherConditionCode.RainLevel.LevelBoundary.RAIN.getThresholdValue() + 0.42;
+
     @InjectMocks
     private PestService pestService;
 
@@ -60,7 +84,7 @@ public class PestServiceTest {
     }
 
     @Test
-    void 귤() {
+    void 귤과_귤응애() {
         // given
         long memberId = 42L;
         int nx = 60;
@@ -69,5 +93,116 @@ public class PestServiceTest {
         final Member member = new Member(memberId, "", "", "", "", null, farm);
         when(farmRepo.findByMember_Id(memberId)).thenReturn(Optional.of(farm));
 
+        // 발생 조건 만들기
+        WeatherConditionCode wc1 = new WeatherConditionCode(HumidityLevel.LOW, TemperatureLevel.MID, RainLevel.NONE);
+
+        // 작물
+        Long myCropId = 42L;
+        Crop 귤 = new Crop(42L, "귤", new ArrayList<>());
+        MyCrop 마이귤 = new MyCrop(myCropId, 귤, member, LocalDateTime.now());
+        when(myCropRepo.findAllByMember_IdOrderById(memberId)).thenReturn(List.of(마이귤));
+        when(myCropRepo.findAllByMember_IdOrderByCrop_Id(memberId)).thenReturn(List.of(마이귤));
+        when(myCropRepo.findById(42L)).thenReturn(Optional.of(마이귤));
+
+        // 날씨
+        ShortTermWeatherForecast fcst1 = ShortTermWeatherForecast.builder()
+                .humidity(건조)
+                .temperature(보통기온)
+                .precipitation(비없음)
+                .build();
+        when(fcstRepo.findAllByNxAndNy(nx, ny)).thenReturn(List.of(fcst1));
+
+        PestRisk 귤응애 = new PestRisk(
+                42L,
+                "귤응애",
+                "잎과 과실을 흡즙해 엽록소가 파괴되어 표면에 흰색 반점이 생깁니다.",
+                new ArrayList<>(),
+                귤
+        );
+        PestCondition cond1 = PestCondition.builder()
+                .pestConditionId(42L)
+                .pestRisk(귤응애)
+                .startMonth(Month.JULY)
+                .startMonthPhase(PestCondition.MonthPhase.EARLY)
+                .endMonth(Month.AUGUST)
+                .endMonthPhase(PestCondition.MonthPhase.MID)
+                .humidityLevel(HumidityLevel.LOW)
+                .temperatureLevel(TemperatureLevel.MID)
+                .rainLevel(RainLevel.DONT_CARE)
+                .build();
+        귤응애.addCondition(cond1);
+        귤.addPestRisk(귤응애);
+
+        // expected
+        var pestCards = List.of(귤응애.toCard());
+        //var cropCards = List.of(new GetPestCardListResponse.MyCropCard(마이귤.getId(), 마이귤.getCrop().getName()));
+        var cropCards = new ArrayList<GetPestCardListResponse.MyCropCard>();
+        var expected = new GetPestCardListResponse(pestCards, cropCards);
+
+        // actual
+        var actual = pestService.getPestCardList(memberId, myCropId);
+        assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    void 귤과_귤응애_when_myCropId_is_null() {
+        // given
+        long memberId = 42L;
+        int nx = 60;
+        int ny = 120;
+        final Farm farm = new Farm(memberId, "", "", "", "", 36.12, 127.12, nx, ny, "regioncode", null);
+        final Member member = new Member(memberId, "", "", "", "", null, farm);
+        when(farmRepo.findByMember_Id(memberId)).thenReturn(Optional.of(farm));
+
+        // 발생 조건 만들기
+        WeatherConditionCode wc1 = new WeatherConditionCode(HumidityLevel.LOW, TemperatureLevel.MID, RainLevel.NONE);
+
+        // 작물
+        Long myCropId = 42L;
+        Crop 귤 = new Crop(42L, "귤", new ArrayList<>());
+        MyCrop 마이귤 = new MyCrop(myCropId, 귤, member, LocalDateTime.now());
+        when(myCropRepo.findAllByMember_IdOrderById(memberId)).thenReturn(List.of(마이귤));
+        when(myCropRepo.findAllByMember_IdOrderByCrop_Id(memberId)).thenReturn(List.of(마이귤));
+        when(myCropRepo.findById(42L)).thenReturn(Optional.of(마이귤));
+
+        // 날씨
+        ShortTermWeatherForecast fcst1 = ShortTermWeatherForecast.builder()
+                .humidity(건조)
+                .temperature(보통기온)
+                .precipitation(비없음)
+                .build();
+        when(fcstRepo.findAllByNxAndNy(nx, ny)).thenReturn(List.of(fcst1));
+
+        PestRisk 귤응애 = new PestRisk(
+                42L,
+                "귤응애",
+                "잎과 과실을 흡즙해 엽록소가 파괴되어 표면에 흰색 반점이 생깁니다.",
+                new ArrayList<>(),
+                귤
+        );
+        PestCondition cond1 = PestCondition.builder()
+                .pestConditionId(42L)
+                .pestRisk(귤응애)
+                .startMonth(Month.JULY)
+                .startMonthPhase(PestCondition.MonthPhase.EARLY)
+                .endMonth(Month.AUGUST)
+                .endMonthPhase(PestCondition.MonthPhase.MID)
+                .humidityLevel(HumidityLevel.LOW)
+                .temperatureLevel(TemperatureLevel.MID)
+                .rainLevel(RainLevel.DONT_CARE)
+                .build();
+        귤응애.addCondition(cond1);
+        귤.addPestRisk(귤응애);
+
+        // expected
+        var pestCards = List.of(귤응애.toCard());
+        var cropCards = List.of(new GetPestCardListResponse.MyCropCard(마이귤.getId(), 마이귤.getCrop().getName()));
+//        var cropCards = new ArrayList<GetPestCardListResponse.MyCropCard>();
+        var expected = new GetPestCardListResponse(pestCards, cropCards);
+
+        // actual
+        var actual = pestService.getPestCardList(memberId, null);
+        assertThat(actual).isEqualTo(expected);
+    }
+
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
@@ -1,0 +1,73 @@
+package com.imsnacks.Nyeoreumnagi.pest.service;
+
+import com.imsnacks.Nyeoreumnagi.member.entity.Farm;
+import com.imsnacks.Nyeoreumnagi.member.entity.Member;
+import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
+import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
+import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
+import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
+import com.imsnacks.Nyeoreumnagi.work.repository.MyCropRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+public class PestServiceTest {
+    @InjectMocks
+    private PestService pestService;
+
+    @Mock
+    private FarmRepository farmRepo;
+
+    @Mock
+    private ShortTermWeatherForecastRepository fcstRepo;
+
+    @Mock
+    private MyCropRepository myCropRepo;
+
+    @Test
+    void 멤버가_없는_경우_예외를_던진다() {
+        final long wrongMemberId = 42L;
+        when(farmRepo.findByMember_Id(wrongMemberId)).thenReturn(Optional.empty());
+        try {
+            pestService.getPestCardList(wrongMemberId, null);
+        } catch (MemberException e) {
+            assertThat(e.getStatus()).isEqualTo(MemberResponseStatus.NO_FARM_INFO);
+        }
+    }
+
+    @Test
+    void 농장이_없는_경우_예외를_던진다() {
+        final long memberId = 42L;
+        final Member member = new Member(memberId, "", "", "", "", null, null);
+        when(farmRepo.findByMember_Id(memberId)).thenReturn(Optional.empty());
+        try {
+            pestService.getPestCardList(memberId, null);
+        } catch(MemberException e) {
+            assertThat(e.getStatus()).isEqualTo(MemberResponseStatus.NO_FARM_INFO);
+        }
+    }
+
+    @Test
+    void 귤() {
+        // given
+        long memberId = 42L;
+        int nx = 60;
+        int ny = 120;
+        final Farm farm = new Farm(memberId, "", "", "", "", 36.12, 127.12, nx, ny, "regioncode", null);
+        final Member member = new Member(memberId, "", "", "", "", null, farm);
+        when(farmRepo.findByMember_Id(memberId)).thenReturn(Optional.of(farm));
+
+    }
+}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #326

---

## 📝작업 내용

- 사용자의 작물이 현재 날씨에 의해 받을 수 있는 병해충 피해 목록을 반환함
- 24시간 이내 기상 상황에서 해당 작물에 발생할 수 있는 병해충 이름 / 피해 설명 표시
- 최대 6건 표시 (노출 기준 개발진 임의 설정)

PestRisks

- myCropId가 유효하면 myCropId의 MyCrop과 연관된 병해충 피해 목록을 반환함
- myCropId가 null이면 myCropId 중 가장 작은 crop의 병해충 피해 목록을 반환함
- 발생 조건에 맞는 병해충이 현재 없다면 임의의 작물과 연관된 병해충 목록를 반환함

MyCrops

- myCropId가 null이면 member의 myCrop 리스트를 반환함
- myCropId가 유효하면 빈 리스트를 반환함

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

아직 컨트롤러는 만들지 못 했습니다. 추가 이슈를 생성해 만들도록 하겠습니다.


---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)