### PR TITLE
[Feat] accessToken reissue 기능

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
@@ -11,10 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -32,4 +31,15 @@ public class AuthController {
         LoginResponse response = authService.login(request);
         return ResponseUtil.success(response);
     }
+
+    @GetMapping("/refresh")
+    @Operation(summary = "accessToken 재발급")
+    @ApiResponse(responseCode = "200", description = "accessToken 재발급 성공")
+    @ApiResponse(responseCode = "400", description = "accessToken 재발급 실패")
+    public ResponseEntity<CustomResponseBody<LoginResponse>> refreshToken(@RequestHeader UUID refreshToken){
+        LoginResponse response = authService.refreshToken(refreshToken);
+        return ResponseUtil.success(response);
+    }
+
+
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 import static com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus.*;
 
 @Service
@@ -31,6 +33,14 @@ public class AuthService {
         AuthTokens token = jwtProvider.createToken(member.getId());
         member.setRefreshToken(token.getRefreshToken());
 
+        return new LoginResponse(member.getNickname(), token.getAccessToken(), token.getRefreshToken());
+    }
+
+    @Transactional
+    public LoginResponse refreshToken(UUID refreshToken){
+        Member member = memberRepository.findByRefreshToken(refreshToken).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        AuthTokens token = jwtProvider.createToken(member.getId());
         return new LoginResponse(member.getNickname(), token.getAccessToken(), token.getRefreshToken());
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/member/repository/MemberRepository.java
@@ -4,7 +4,10 @@ import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findOneByIdentifier(String identifier);
+
+    Optional<Member> findByRefreshToken(UUID refreshToken);
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthServiceTest.java
@@ -1,0 +1,70 @@
+package com.imsnacks.Nyeoreumnagi.common.auth.service;
+
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.request.LoginRequest;
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.AuthTokens;
+import com.imsnacks.Nyeoreumnagi.common.auth.jwt.JwtProvider;
+import com.imsnacks.Nyeoreumnagi.member.entity.Member;
+import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void login_성공_시_토큰_저장_후_응답을_반환한다() {
+        // Given (준비)
+        LoginRequest request = new LoginRequest("test_user", "password123");
+        Member mockMember = new Member(1L, "test_user", "password123", "테스트유저", "010-1234-5678", null, null);
+        AuthTokens mockTokens = new AuthTokens("mock_access_token", UUID.randomUUID());
+
+        when(memberRepository.findOneByIdentifier(request.identifier())).thenReturn(Optional.of(mockMember));
+        when(jwtProvider.createToken(mockMember.getId())).thenReturn(mockTokens);
+
+        // When (실행)
+        LoginResponse response = authService.login(request);
+
+        // Then (검증)
+        assertThat(response.nickname()).isEqualTo("테스트유저");
+        assertThat(response.accessToken()).isEqualTo("mock_access_token");
+        assertThat(response.refreshToken()).isEqualTo(mockTokens.getRefreshToken());
+    }
+
+    @Test
+    void refreshToken_재발급_성공_시_새로운_토큰을_반환한다() {
+        // Given (준비)
+        UUID oldRefreshToken = UUID.randomUUID();
+        Member mockMember = new Member(1L, "test_user", "password123", "테스트유저", "010-1234-5678", oldRefreshToken, null);
+        AuthTokens newMockTokens = new AuthTokens("new_access_token", UUID.randomUUID());
+
+        when(memberRepository.findByRefreshToken(oldRefreshToken)).thenReturn(Optional.of(mockMember));
+        when(jwtProvider.createToken(mockMember.getId())).thenReturn(newMockTokens);
+
+        // When (실행)
+        LoginResponse response = authService.refreshToken(oldRefreshToken);
+
+        // Then (검증)
+        assertThat(response.nickname()).isEqualTo("테스트유저");
+        assertThat(response.accessToken()).isEqualTo("new_access_token");
+        assertThat(response.refreshToken()).isEqualTo(newMockTokens.getRefreshToken());
+    }
+}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #406

---

## 📝작업 내용

1. refreshToken으로 accessToken과 refreshToken을 재발급받는 기능을 구현했습니다.
- 반환 형식은 로그인 응답과 같습니다.
- 요청 시 헤더에 `refreshToken` 키 값으로 토큰을 담도록 했습니다.


---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)