### PR TITLE
[Refactor] 기상 리스크별 작물 피해 카드 description의 글자수를 공백 포함 40자 이내로 수정

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/weatherRisk/enums/WeatherRiskCard.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/weatherRisk/enums/WeatherRiskCard.java
@@ -9,11 +9,11 @@ import static com.imsnacks.Nyeoreumnagi.common.enums.WeatherRiskType.*;
 import static com.imsnacks.Nyeoreumnagi.weather.exception.WeatherResponseStatus.NO_MATCHING_WEATHER_RISK_CARD;
 
 public enum WeatherRiskCard {
-    SUNBURN("햇볕 데임", "햇빛 가림망을 설치하고 작물에 물 주는 시기를 짧게 자주 하는 것이 좋아요."),
+    SUNBURN("햇볕 데임", "햇빛 가림망을 설치하고 물 주는 시기를 짧게 자주 하는 것이 좋아요."),
     WATER_DEFICIENCY("수분 부족", "토양 수분 증발을 줄이기 위해 지면에 퇴비, 짚, 풀을 깔아보세요."),
-    POOR_COLORING("착색 불량", "가지 유인과 과실 돌리기를 통해 과실이 강한 햇빛에 노출되지 않도록 해주세요."),
+    POOR_COLORING("착색 불량", "가지 유인과 과실 돌리기를 통해 과실이 햇빛에 노출되지 않도록 해주세요."),
     FRUIT_CRAKING("열과", "토양수분의 급격한 변화가 발생하지 않도록 배수 관리를 철저히 해주세요."),
-    FRUIT_DROP("낙과", "점적관수, 미세살수로 일정하고 소량의 물을 꾸준히 공급해 토양 수분 변동을 최소화 해주세요."),
+    FRUIT_DROP("낙과", "미세살수로 소량의 물을 꾸준히 공급해 토양 수분 변동을 최소화 하세요."),
     FLOWER_DROP("낙화", "강한 비가 올 때 배수관리를 철저히 해 꽃 떨어짐을 예방하세요."),
     ;
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #409 

---

## 📝작업 내용

1. 홈페이지에서 보여질 기상 리스크별 작물 피해 카드 description을 UI 이슈로 인해  글자수를 공백 포함 40자 이내로 수정했습니다. 

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)