### PR TITLE
[Fix] 요청의 MyCropId가 요청자의 소유가 아닌 경우 예외 처리

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/pest/package-info.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/pest/package-info.java
@@ -1,1 +1,0 @@
-package com.imsnacks.Nyeoreumnagi.damage.pest;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/pest/service/PestService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/damage/pest/service/PestService.java
@@ -41,7 +41,7 @@ public class PestService {
 
     public GetPestCardListResponse getPestCardList(final Long memberId, @Nullable final Long myCropId) {
         final Farm farm = farmRepo.findByMember_Id(memberId).orElseThrow(() -> new MemberException(MemberResponseStatus.NO_FARM_INFO));
-        final Crop target = (myCropId == null) ? findDefaultCrop(memberId) : findCropBy(myCropId);
+        final Crop target = (myCropId == null) ? findDefaultCrop(memberId) : findCropBy(myCropId, memberId);
         final List<PestCard> pestCards = getPestCards(target, farm.getNx(), farm.getNy());
         final List<MyCropCard> myCropCards = (myCropId == null) ? getMyCropCards(memberId) : new ArrayList<>();
 
@@ -79,8 +79,11 @@ public class PestService {
         return crop;
     }
 
-    private Crop findCropBy(@NotNull long myCropId) {
+    private Crop findCropBy(long myCropId, long memberId) {
         final MyCrop myCrop = myCropRepo.findById(myCropId).orElseThrow(() -> new CropException(CropResponseStatus.MY_CROP_NOT_FOUND));
+        if (!myCrop.getMember().getId().equals(memberId)) {
+            throw new CropException(CropResponseStatus.MY_CROP_NOT_YOURS);
+        }
         final Crop crop = myCrop.getCrop();
         if (crop == null) {
             throw new CropException(CropResponseStatus.MY_CROP_NOT_FOUND);

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/CropResponseStatus.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/exception/CropResponseStatus.java
@@ -1,7 +1,8 @@
 package com.imsnacks.Nyeoreumnagi.work.exception;
 
 public enum CropResponseStatus {
-    MY_CROP_NOT_FOUND(6001, "내 작물이 존재하지 않습니다.")
+    MY_CROP_NOT_FOUND(6001, "내 작물이 존재하지 않습니다."),
+    MY_CROP_NOT_YOURS(6002, "사용자에게 등록된 내 작물이 아닙니다.")
     ;
     private int code;
     private String message;

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
@@ -161,8 +161,7 @@ public class PestServiceTest {
 
         // expected
         var pestCards = List.of(귤응애.toCard());
-        //var cropCards = List.of(new GetPestCardListResponse.MyCropCard(마이귤.getId(), 마이귤.getCrop().getName()));
-        var cropCards = new ArrayList<GetPestCardListResponse.MyCropCard>();
+        var cropCards = List.of(마이귤.toCard());
         var expected = new GetPestCardListResponse(pestCards, cropCards);
 
         // actual
@@ -285,8 +284,7 @@ public class PestServiceTest {
 
         // expected
         var pestCards = List.of(귤응애.toCard());
-        //var cropCards = List.of(new GetPestCardListResponse.MyCropCard(마이귤.getId(), 마이귤.getCrop().getName()));
-        var cropCards = new ArrayList<GetPestCardListResponse.MyCropCard>();
+        var cropCards = List.of(마이귤.toCard());
         var expected = new GetPestCardListResponse(pestCards, cropCards);
 
         // actual
@@ -407,7 +405,7 @@ public class PestServiceTest {
         // expected
         var pestCards = List.of(귤응애.toCard(), 왕담배나방.toCard(), 어떤병.toCard());
         //var cropCards = List.of(new GetPestCardListResponse.MyCropCard(마이귤.getId(), 마이귤.getCrop().getName()));
-        var cropCards = new ArrayList<GetPestCardListResponse.MyCropCard>();
+        var cropCards = List.of(마이귤.toCard());
         var expected = new GetPestCardListResponse(pestCards, cropCards);
         LocalDateTime testDate = LocalDateTime.of(2025, 8, 18, 10, 10);
         // actual

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/pest/service/PestServiceTest.java
@@ -1,25 +1,26 @@
 package com.imsnacks.Nyeoreumnagi.pest.service;
 
+import com.imsnacks.Nyeoreumnagi.damage.pest.dto.response.GetPestCardListResponse;
+import com.imsnacks.Nyeoreumnagi.damage.pest.entity.PestCondition;
+import com.imsnacks.Nyeoreumnagi.damage.pest.entity.PestRisk;
 import com.imsnacks.Nyeoreumnagi.damage.pest.enums.DamageType;
 import com.imsnacks.Nyeoreumnagi.damage.pest.service.PestService;
 import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode;
+import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.HumidityLevel;
+import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.RainLevel;
+import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.TemperatureLevel;
 import com.imsnacks.Nyeoreumnagi.member.entity.Farm;
 import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
 import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
-import com.imsnacks.Nyeoreumnagi.damage.pest.dto.response.GetPestCardListResponse;
-import com.imsnacks.Nyeoreumnagi.damage.pest.entity.PestCondition;
-import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.HumidityLevel;
-import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.RainLevel;
-import com.imsnacks.Nyeoreumnagi.damage.pest.service.WeatherConditionCode.TemperatureLevel;
-import com.imsnacks.Nyeoreumnagi.damage.pest.entity.PestRisk;
 import com.imsnacks.Nyeoreumnagi.weather.entity.ShortTermWeatherForecast;
 import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
 import com.imsnacks.Nyeoreumnagi.work.entity.Crop;
 import com.imsnacks.Nyeoreumnagi.work.entity.MyCrop;
+import com.imsnacks.Nyeoreumnagi.work.exception.CropException;
+import com.imsnacks.Nyeoreumnagi.work.exception.CropResponseStatus;
 import com.imsnacks.Nyeoreumnagi.work.repository.MyCropRepository;
-import net.bytebuddy.asm.Advice;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -83,8 +84,27 @@ public class PestServiceTest {
         when(farmRepo.findByMember_Id(memberId)).thenReturn(Optional.empty());
         try {
             pestService.getPestCardList(memberId, null);
-        } catch(MemberException e) {
+        } catch (MemberException e) {
             assertThat(e.getStatus()).isEqualTo(MemberResponseStatus.NO_FARM_INFO);
+        }
+    }
+
+    @Test
+    void 요청을_보낸_멤버의_작물이_아닌_경우_예외를_던진다() {
+        long myId = 42L;
+        int nx = 60;
+        int ny = 120;
+        Farm farm = new Farm(myId, "", "", "", "", 36.12, 127.12, nx, ny, "regioncode", null);
+        Member other = new Member(77L, "", "", "", "", null, farm);
+        MyCrop myCrop = new MyCrop(1L, null, other, null);
+
+        when(farmRepo.findByMember_Id(myId)).thenReturn(Optional.of(farm));
+        when(myCropRepo.findById(1L)).thenReturn(Optional.of(myCrop));
+
+        try {
+            pestService.getPestCardList(myId, 1L);
+        } catch (CropException e) {
+            assertThat(e.getStatus()).isEqualTo(CropResponseStatus.MY_CROP_NOT_YOURS);
         }
     }
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #399 

---

## 📝작업 내용

CropResponseStatus 추가
CropResponseStatus.MY_CROP_NOT_YOURS: 6002, 요청자에게 등록된 myCropId가 아닌 경우.

병해충 리스크 요청의 myCropId가 요청자의 소유가 아닌 경우, MY_CROP_NOT_YOURS(6002) 예외를 반환합니다.

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)