### PR TITLE
[Fix] accessToken 재발급 시 refreshToken을 쿠키로 보내도록 변경

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.imsnacks.Nyeoreumnagi.common.auth.controller;
 
 import com.imsnacks.Nyeoreumnagi.common.auth.dto.request.LoginRequest;
 import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse;
+import com.imsnacks.Nyeoreumnagi.common.auth.dto.response.LoginResponse.LoginAccessTokenResponse;
 import com.imsnacks.Nyeoreumnagi.common.auth.service.AuthService;
 import com.imsnacks.Nyeoreumnagi.common.response.CustomResponseBody;
 import com.imsnacks.Nyeoreumnagi.common.response.ResponseUtil;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -26,17 +26,18 @@ public class AuthController {
     @Operation(summary = "로그인")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @ApiResponse(responseCode = "400", description = "로그인 실패")
-    public ResponseEntity<CustomResponseBody<LoginResponse>> login(@RequestBody LoginRequest request){
+    public ResponseEntity<CustomResponseBody<LoginAccessTokenResponse>> login(@RequestBody LoginRequest request){
         request.validate();
         LoginResponse response = authService.login(request);
-        return ResponseUtil.success(response);
+
+        return ResponseUtil.success(response.loginAccessTokenResponse(), response.refreshToken());
     }
 
     @GetMapping("/refresh")
     @Operation(summary = "accessToken 재발급")
     @ApiResponse(responseCode = "200", description = "accessToken 재발급 성공")
     @ApiResponse(responseCode = "400", description = "accessToken 재발급 실패")
-    public ResponseEntity<CustomResponseBody<LoginResponse>> refreshToken(@RequestHeader UUID refreshToken){
+    public ResponseEntity<CustomResponseBody<LoginResponse>> refreshToken(@CookieValue(name = "refreshToken") UUID refreshToken){
         LoginResponse response = authService.refreshToken(refreshToken);
         return ResponseUtil.success(response);
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/dto/response/LoginResponse.java
@@ -1,10 +1,14 @@
 package com.imsnacks.Nyeoreumnagi.common.auth.dto.response;
 
+
 import java.util.UUID;
 
 public record LoginResponse(
-        String nickname,
-        String accessToken,
-        UUID refreshToken
+        UUID refreshToken,
+        LoginAccessTokenResponse loginAccessTokenResponse
 ) {
+    public record LoginAccessTokenResponse(
+            String nickname,
+            String accessToken
+    ){}
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService {
         AuthTokens token = jwtProvider.createToken(member.getId());
         member.setRefreshToken(token.getRefreshToken());
 
-        return new LoginResponse(member.getNickname(), token.getAccessToken(), token.getRefreshToken());
+        return new LoginResponse(token.getRefreshToken(), new LoginResponse.LoginAccessTokenResponse(member.getNickname(), token.getAccessToken()));
     }
 
     @Transactional
@@ -41,6 +41,6 @@ public class AuthService {
         Member member = memberRepository.findByRefreshToken(refreshToken).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         AuthTokens token = jwtProvider.createToken(member.getId());
-        return new LoginResponse(member.getNickname(), token.getAccessToken(), token.getRefreshToken());
+        return new LoginResponse(token.getRefreshToken(), new LoginResponse.LoginAccessTokenResponse(member.getNickname(), token.getAccessToken()));
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/response/ResponseUtil.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/response/ResponseUtil.java
@@ -1,12 +1,27 @@
 package com.imsnacks.Nyeoreumnagi.common.response;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
 
 public class ResponseUtil {
 
     public static <T> ResponseEntity<CustomResponseBody<T>> success(T data) {
         return ResponseEntity.ok(new CustomResponseBody<>(StatusCode.SUCCESS.getCode(),StatusCode.SUCCESS.getMessage(), data));
+    }
+
+    public static <T> ResponseEntity<CustomResponseBody<T>> success(T data, UUID refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken.toString())
+                .path("/")
+                .maxAge(86400 * 3)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(new CustomResponseBody<>(StatusCode.SUCCESS.getCode(),StatusCode.SUCCESS.getMessage(), data));
     }
 
     public static <T> ResponseEntity<CustomResponseBody<T>> success() {

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/controller/AuthControllerTest.java
@@ -56,7 +56,7 @@ class AuthControllerTest {
 
         LoginResponse response = authService.login(request);
 
-        assertThat(response.accessToken()).isEqualTo(accessToken);
+        assertThat(response.loginAccessTokenResponse().accessToken()).isEqualTo(accessToken);
         assertThat(response.refreshToken()).isEqualTo(refreshToken);
 
         verify(memberRepository, times(1)).findOneByIdentifier(identifier);

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthServiceTest.java
@@ -44,8 +44,8 @@ class AuthServiceTest {
         LoginResponse response = authService.login(request);
 
         // Then (검증)
-        assertThat(response.nickname()).isEqualTo("테스트유저");
-        assertThat(response.accessToken()).isEqualTo("mock_access_token");
+        assertThat(response.loginAccessTokenResponse().nickname()).isEqualTo("테스트유저");
+        assertThat(response.loginAccessTokenResponse().accessToken()).isEqualTo("mock_access_token");
         assertThat(response.refreshToken()).isEqualTo(mockTokens.getRefreshToken());
     }
 
@@ -63,8 +63,8 @@ class AuthServiceTest {
         LoginResponse response = authService.refreshToken(oldRefreshToken);
 
         // Then (검증)
-        assertThat(response.nickname()).isEqualTo("테스트유저");
-        assertThat(response.accessToken()).isEqualTo("new_access_token");
+        assertThat(response.loginAccessTokenResponse().nickname()).isEqualTo("테스트유저");
+        assertThat(response.loginAccessTokenResponse().accessToken()).isEqualTo("new_access_token");
         assertThat(response.refreshToken()).isEqualTo(newMockTokens.getRefreshToken());
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #418

---

## 📝작업 내용

1. accessToken 재발급 시 refreshToken을 쿠키로 보내도록 변경했습니다.
2. 로그인을 할 때도 body에 refreshToken을 담는 것이 아니라 cookie에 담도록 했습니다. (만료기한 3일) 

---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)