### PR TITLE
[Fix]  refreshToken cookie에 httpOnly 설정

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/response/ResponseUtil.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/response/ResponseUtil.java
@@ -17,6 +17,7 @@ public class ResponseUtil {
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken.toString())
                 .path("/")
                 .maxAge(86400 * 3)
+                .httpOnly(true)
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
## 📌 연관된 이슈

- close #421

---

## 📝작업 내용

refreshToken cookie에 httpOnly true로 설정했습니다.


---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)