### PR TITLE
[Fix] accessToken 재발급 시 refreshToken도 저장

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/common/auth/service/AuthService.java
@@ -41,6 +41,8 @@ public class AuthService {
         Member member = memberRepository.findByRefreshToken(refreshToken).orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
         AuthTokens token = jwtProvider.createToken(member.getId());
+        member.setRefreshToken(token.getRefreshToken());
+
         return new LoginResponse(token.getRefreshToken(), new LoginResponse.LoginAccessTokenResponse(member.getNickname(), token.getAccessToken()));
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #438

---

## 📝작업 내용

accessToken 재발급 시 refreshToken도 저장했습니다.


---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)