### PR TITLE
[Refactor] 단기예보 batch Writer에서 shadow table을 update하도록 수정

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/SchedulingConfig.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/SchedulingConfig.java
@@ -1,0 +1,17 @@
+package com.ImSnacks.NyeoreumnagiBatch;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        return scheduler;
+    }
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobConfig.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/WeatherJobConfig.java
@@ -6,6 +6,7 @@ import com.ImSnacks.NyeoreumnagiBatch.seven_days_weather_forecast.reader.SevenDa
 import com.ImSnacks.NyeoreumnagiBatch.seven_days_weather_forecast.reader.SevenDayWeatherConditionReader;
 import com.ImSnacks.NyeoreumnagiBatch.seven_days_weather_forecast.writer.SevenDayTemperatureWriter;
 import com.ImSnacks.NyeoreumnagiBatch.seven_days_weather_forecast.writer.SevenDayWeatherConditionWriter;
+import com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.ShadowTableInitTasklet;
 import com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.processor.WeatherProcessor;
 import com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.reader.WeatherReader;
 import com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.reader.dto.VilageFcstResponseDto;
@@ -38,9 +39,10 @@ public class WeatherJobConfig {
     private final SevenDayTemperatureWriter sevenDayTemperatureWriter;
 
     @Bean
-    public Job weatherJob(JobRepository jobRepository, Step weatherStep) {
+    public Job weatherJob(JobRepository jobRepository, Step weatherStep, Step shadowTableInitStep) {
         return new JobBuilder("weatherJob", jobRepository)
-                .start(weatherStep)
+                .start(shadowTableInitStep)
+                .next(weatherStep)
                 .build();
     }
 
@@ -68,6 +70,14 @@ public class WeatherJobConfig {
                 .reader(weatherReader)
                 .processor(weatherProcessor)
                 .writer(weatherWriter)
+                .build();
+    }
+
+    @Bean
+    public Step shadowTableInitStep(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+                                    ShadowTableInitTasklet shadowTableInitTasklet) {
+        return new StepBuilder("shadowTableInitStep", jobRepository)
+                .tasklet(shadowTableInitTasklet, transactionManager)
                 .build();
     }
 

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/ShortTermWeatherForecast.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/ShortTermWeatherForecast.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "ShortTermWeatherForecast")
+@Table(name = "short_term_weather_forecast")
 @IdClass(ShortTermWeatherForecastId.class)
 @Getter
 @NoArgsConstructor

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/ShortTermWeatherForecastShadow.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/ShortTermWeatherForecastShadow.java
@@ -1,0 +1,56 @@
+package com.ImSnacks.NyeoreumnagiBatch.common.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "short_term_weather_forecast_shadow")
+@IdClass(ShortTermWeatherForecastId.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class ShortTermWeatherForecastShadow {
+    @Id
+    private int nx;
+
+    @Id
+    private int ny;
+
+    @Id
+    @Column(name = "fcst_time")
+    private int fcstTime;
+
+    @Column(nullable = false)
+    private double precipitation;
+
+    @Column(nullable = false)
+    private int temperature;
+
+    @Column(nullable = false)
+    private int humidity;
+
+    @Column(name = "wind_speed", nullable = false)
+    private double windSpeed;
+
+    @Column(name = "snow", nullable = false)
+    private double snow;
+
+    @Column(name = "sky_status", nullable = false)
+    private int skyStatus;
+
+    @Column(name = "wind_direction", nullable = false)
+    private int wind_direction;
+
+    @LastModifiedDate
+    @Column(name = "update_at")
+    private LocalDateTime updateAt;
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/WeatherRisk.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/WeatherRisk.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "WeatherRisk")
+@Table(name = "weather_risk")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/WeatherRiskShadow.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/entity/WeatherRiskShadow.java
@@ -1,0 +1,28 @@
+package com.ImSnacks.NyeoreumnagiBatch.common.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "weather_risk_shadow")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WeatherRiskShadow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long weatherRiskId;
+    private long jobExecutionId;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private int nx;
+    private int ny;
+    @Enumerated(EnumType.STRING)
+    private WeatherRiskType name;
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/ShortTermWeatherForecastShadowRepository.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/ShortTermWeatherForecastShadowRepository.java
@@ -1,0 +1,9 @@
+package com.ImSnacks.NyeoreumnagiBatch.common.repository;
+
+import com.ImSnacks.NyeoreumnagiBatch.common.entity.ShortTermWeatherForecastId;
+import com.ImSnacks.NyeoreumnagiBatch.common.entity.ShortTermWeatherForecastShadow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShortTermWeatherForecastShadowRepository extends JpaRepository<ShortTermWeatherForecastShadow, ShortTermWeatherForecastId> {
+
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/WeatherRiskRepository.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/WeatherRiskRepository.java
@@ -1,6 +1,7 @@
-package com.ImSnacks.NyeoreumnagiBatch.common.entity;
+package com.ImSnacks.NyeoreumnagiBatch.common.repository;
 
 
+import com.ImSnacks.NyeoreumnagiBatch.common.entity.WeatherRisk;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WeatherRiskRepository extends JpaRepository<WeatherRisk, Long> {

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/WeatherRiskShadowRepository.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/common/repository/WeatherRiskShadowRepository.java
@@ -1,0 +1,8 @@
+package com.ImSnacks.NyeoreumnagiBatch.common.repository;
+
+
+import com.ImSnacks.NyeoreumnagiBatch.common.entity.WeatherRiskShadow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeatherRiskShadowRepository extends JpaRepository<WeatherRiskShadow, Long> {
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/ShadowTableInitTasklet.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/ShadowTableInitTasklet.java
@@ -1,0 +1,26 @@
+package com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShadowTableInitTasklet implements Tasklet {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS short_term_weather_forecast_shadow LIKE short_term_weather_forecast");
+        jdbcTemplate.execute("TRUNCATE TABLE short_term_weather_forecast_shadow");
+
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS weather_risk_shadow LIKE weather_risk");
+        jdbcTemplate.execute("TRUNCATE TABLE weather_risk_shadow");
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -51,10 +51,10 @@ spring:
       enabled: true
       path: /h2-console
   datasource:
-    url: jdbc:h2:./batchdb;MODE=MySQL;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:${RDS_PORT}/${RDS_DATABASE}?useSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${RDS_USERNAME}
+    password: ${RDS_PASSWORD}
 
 ---
 

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -24,10 +24,7 @@ spring:
   #      schema-locations: classpath:init-farm.sql
 #      data-locations: classpath:insert_unique_nxny.sql
 
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+
 api:
   service:
     key: ${OPEN_API_KEY}
@@ -55,6 +52,17 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
+
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
 
 ---
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #440 
- close #441 

---

## 📝작업 내용

1. ShortTermWeatherForecast 엔티티의 shadow 엔티티 및 repository 인터페이스 생성
2. WeatherRisk 엔티티의 shadow 엔티티 및 repository 인터페이스 생성
3. 단기예보 batch writer에서 shadow table을 update하도록 수정
4. 단기예보 batch before step으로 shadow table 없으면 create 하도록 step 추가
5. 단기예보 batch after step으로 shadow table rename 하는 메소드 오버라이딩

---

### 스크린샷 (선택)

다음 테이블이 추가적으로 생성됩니다. 

1. entity명 그대로인 table : 실제 api server가 data를 읽는 테이블입니다.
6. entity명 + backup : 배치로 업데이트 하기 이전 정보를 가지고 있는 테이블입니다. 
7. entity명 + shadow : 배치가 업데이트 하는 테이블이고, 배치가 무사히 업데이트하면 rename 됩니다. 

<img width="363" height="172" alt="image" src="https://github.com/user-attachments/assets/f10b013a-2925-4e86-85d4-3deda3183d93" />

---

## 💬리뷰 요구사항

단기예보 논리적 오류는 별도의 이슈를 생성하고 해결하도록 하겠습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)