### PR TITLE
[Fix] Batch Job이 동시에 여러개 실행될 때 발생하는 deadlock 문제 해결

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/BatchConfiguration.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/BatchConfiguration.java
@@ -1,0 +1,59 @@
+package com.ImSnacks.NyeoreumnagiBatch;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.item.database.support.DataFieldMaxValueIncrementerFactory;
+import org.springframework.batch.item.database.support.DefaultDataFieldMaxValueIncrementerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.support.incrementer.DataFieldMaxValueIncrementer;
+import org.springframework.jdbc.support.incrementer.SqlServerMaxValueIncrementer;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfiguration {
+
+  private static final String ISOLATION_REPEATABLE_READ = "ISOLATION_READ_COMMITTED";
+
+  @Autowired
+  private DataSource dataSource;
+  @Autowired
+  private PlatformTransactionManager platformTransactionManager;
+
+  @Bean
+  public JobRepository jobRepository() throws Exception {
+    JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+    factory.setDataSource(dataSource);
+    factory.setTransactionManager(platformTransactionManager);
+    factory.setValidateTransactionState(true);
+    factory.setIsolationLevelForCreate(ISOLATION_REPEATABLE_READ);
+    factory.setIncrementerFactory(customIncrementerFactory());
+    factory.afterPropertiesSet();
+    return factory.getObject();
+  }
+
+  private DataFieldMaxValueIncrementerFactory customIncrementerFactory() {
+    return new CustomDataFieldMaxValueIncrementerFactory(dataSource);
+  }
+
+  private class CustomDataFieldMaxValueIncrementerFactory extends DefaultDataFieldMaxValueIncrementerFactory {
+
+    CustomDataFieldMaxValueIncrementerFactory(DataSource dataSource) {
+      super(dataSource);
+    }
+
+    @Override
+    public DataFieldMaxValueIncrementer getIncrementer(String incrementerType, String incrementerName) {
+      DataFieldMaxValueIncrementer incrementer = super.getIncrementer(incrementerType, incrementerName);
+      if (incrementer instanceof SqlServerMaxValueIncrementer) {
+        ((SqlServerMaxValueIncrementer) incrementer).setCacheSize(20);
+      }
+      return incrementer;
+    }
+  }
+}

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -12,6 +12,9 @@ spring:
         format_sql: true
         highlight_sql: true
 
+  main:
+    allow-bean-definition-overriding: true
+
 
   batch:
     job:


### PR DESCRIPTION
## 📌 연관된 이슈

- close #461 

---

## 📝작업 내용

Job이 실행될 때 MySQL에서 중복 Job인지 check하는 과정은 다음과 같습니다. 
1. Job은 Job Name + Job Key 조합으로 서로 식별한다. 
2. Spring Batch는 DB에 default로 `BATCH_JOB_INSTANCE`라는 테이블을 생성하고, 새로운 Job을 실행할 때 기존에 있던 Job인지 판단하기 위해 Job name, Job key에 대해 unique index인 `JOB_INST_UN` 을 생성해둔다. 
3. 새로운 Job이 실행되면 `JOB_INST_UN` 를 통해 중복된 index 값이 있는지 판단한다. 
4. 없으면 해당 테이블에 새로운 record를 생성해야 한다. 근데 index이기 때문에 정렬된 상태로 insert 된다. 
5. 먼저 `Shared Gap Lock`을 가진다. 그리고나서 `Insert-Intention Lock`을 얻어낸 후 insert 연산을 수행한다. 
    a. `Shared Gap Lock` : 나 이제 insert 할거니까 끼어들지마 (공유락 S)
    b. `Insert-Intention Lock` : 이제 insert 실제로 할게 (베타락 X)


여기서 JOB_INST_UN 인덱스에 대해서 insert를 위한 lock을 걸면서 deallock이 발생하는 것입니다. 

그래서 JobRepository 관련 테이블의 격리수준을 READ_COMMITTED로 커스텀 하는 방식으로 수정했습니다. 

상세한 작업 로그는 노션에 남겼습니다. 
[작업 로그](https://foregoing-sofa-1ca.notion.site/Batch-DeadLock-255e13d9782280bda65eebca8cda0570?source=copy_link)

---

## 💬리뷰 요구사항

없습니다!

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)