### PR TITLE
[Fix] findByIdAndMember_Id() -> findById() 후 memberId 동일성 검증

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
@@ -178,7 +178,12 @@ public class MyWorkService {
     @Transactional
     public void updateMyWorkStatus(UpdateMyWorkStatusRequest request, long memberId){
         Farm farm = farmRepository.findByMember_Id(memberId).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
-        MyWork myWork = myWorkRepository.findByIdAndMember_Id(request.myWorkId(), memberId).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
+        MyWork myWork = myWorkRepository.findById(request.myWorkId()).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
+
+        if(!myWork.getMember().getId().equals(memberId)){
+            throw new WorkException(MY_WORK_NOT_FOUND);
+        }
+
         if (request.status().equals(COMPLETED)) {
             publisher.publishEvent(new MyWorkCompletedEvent(myWork.getMember().getId(),
                     myWork.getRecommendedWork().getId(),


### PR DESCRIPTION
## 📌 연관된 이슈

- close #464

---

## 📝작업 내용

기존에는 memberId와 id로 myWork를 바로 찾고 없으면 예외를 반환했습니다. 원인은 모르겠으나 데이터베이스에 제대로 있는 레코드를 못찾고 있어서 일단 Id로 조회 후에 memberId를 비교하는 걸로 로직을 변경했습니다.

---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)