### PR TITLE
[Feat] 현재보다 이전 시간인 작업 일정 표시

### DIFF
--- a/frontend/src/components/common/PortalComponent.tsx
+++ b/frontend/src/components/common/PortalComponent.tsx
@@ -1,0 +1,39 @@
+import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
+
+interface PortalComponentProps {
+  anchorRef: React.RefObject<HTMLElement | null>;
+  offset?: number;
+  children: React.ReactNode;
+}
+
+const PortalComponent = ({ anchorRef, children }: PortalComponentProps) => {
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(
+    null
+  );
+
+  useEffect(() => {
+    const element = anchorRef.current;
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
+    setPosition({ x: rect.left + rect.width / 2, y: rect.top });
+  }, [anchorRef]);
+
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed',
+        left: position?.x,
+        top: position?.y,
+        transform: 'translate(-50%, -100%)',
+        zIndex: 9999,
+        pointerEvents: 'none',
+      }}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+};
+
+export default PortalComponent;

--- a/frontend/src/components/common/PortalToolTip.tsx
+++ b/frontend/src/components/common/PortalToolTip.tsx
@@ -1,13 +1,13 @@
 import { createPortal } from 'react-dom';
 import { useEffect, useState } from 'react';
+import ToolTip from '../toolTip/ToolTip';
+import type { ToolTipProps } from '../toolTip/ToolTip';
 
-interface PortalComponentProps {
+interface PortalToolTipProps extends ToolTipProps {
   anchorRef: React.RefObject<HTMLElement | null>;
-  offset?: number;
-  children: React.ReactNode;
 }
 
-const PortalComponent = ({ anchorRef, children }: PortalComponentProps) => {
+const PortalToolTip = ({ anchorRef, ...props }: PortalToolTipProps) => {
   const [position, setPosition] = useState<{ x: number; y: number } | null>(
     null
   );
@@ -30,10 +30,10 @@ const PortalComponent = ({ anchorRef, children }: PortalComponentProps) => {
         pointerEvents: 'none',
       }}
     >
-      {children}
+      <ToolTip {...props} />
     </div>,
     document.body
   );
 };
 
-export default PortalComponent;
+export default PortalToolTip;

--- a/frontend/src/components/toolTip/ToolTip.tsx
+++ b/frontend/src/components/toolTip/ToolTip.tsx
@@ -4,7 +4,7 @@ import S from './ToolTip.style';
 import type { TooltipDirectionType, TooltipType } from '@/types/tooltip.type';
 import { useTheme } from '@emotion/react';
 
-interface ToolTipProps {
+export interface ToolTipProps {
   direction: TooltipDirectionType;
   content: ReactNode;
   type: TooltipType;

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.style.ts
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.style.ts
@@ -51,6 +51,7 @@ const WorkCardContainer = (size: Size) => css`
 
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   user-select: none;
+  overflow: visible;
 
   cursor: grab;
 

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
@@ -1,12 +1,12 @@
 import S from './WorkCardRegister.style';
 import WorkCardRegisterContent from '../workCardRegisterContent/WorkCardRegisterContent';
 import useVisibility from '@/hooks/useVisibility';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { WorkBlockType } from '@/types/workCard.type';
 import { useChangeTimeByResize } from '@/pages/homePage/hooks/work/useChangeTimeByResize';
 import { useResizeCollision } from '@/components/dnd/hooks/useResizeCollision';
 import { patchMyWorkTime } from '@/apis/myWork.api';
-import ToolTip from '@/components/toolTip/ToolTip';
+import { css } from '@emotion/react';
 
 interface WorkCardRegisterProps {
   isDragging?: boolean;
@@ -34,6 +34,25 @@ const WorkCardRegister = ({
   const { show, hide, isVisible } = useVisibility();
   const [newWidth, setNewWidth] = useState(block.size.width);
   const [isResizing, setIsResizing] = useState(false);
+  const [isToolTipVisible, setIsToolTipVisible] = useState(false);
+  const [isPassedTime, setIsPassedTime] = useState(block.position.x < 0);
+
+  useEffect(() => {
+    setIsToolTipVisible(
+      !isDragging &&
+        !isResizing &&
+        isVisible &&
+        (isPassedTime ? newWidth + block.position.x : newWidth) < 145
+    );
+    setIsPassedTime(block.position.x < 0);
+  }, [
+    isVisible,
+    isDragging,
+    isResizing,
+    newWidth,
+    isPassedTime,
+    block.position.x,
+  ]);
 
   const { handleResizeCollision } = useResizeCollision({
     containerRef,
@@ -78,7 +97,7 @@ const WorkCardRegister = ({
         onMouseEnter={show}
         onMouseLeave={hide}
       >
-        {!isDragging && !isResizing && isVisible && newWidth < 145 && (
+        {/* {isToolTipVisible && (
           <ToolTip
             direction={'Top'}
             content={
@@ -93,7 +112,7 @@ const WorkCardRegister = ({
             type={'Default'}
             offset={80}
           />
-        )}
+        )} */}
         {/* 왼쪽 리사이징 핸들 */}
         {!isDragging && onResize && (
           <div
@@ -119,13 +138,19 @@ const WorkCardRegister = ({
             onPointerUp={handleResizeEnd}
           />
         )}
-
-        <WorkCardRegisterContent
-          width={newWidth}
-          cropName={block.cropName}
-          workName={block.workName}
-          workTime={block.workTime}
-        />
+        <div
+          css={css`
+            margin-left: ${isPassedTime ? -block.position.x : 0}px;
+          `}
+        >
+          <WorkCardRegisterContent
+            width={isPassedTime ? newWidth + block.position.x : newWidth}
+            cropName={block.cropName}
+            workName={block.workName}
+            workTime={block.workTime}
+            isToolTipVisible={isToolTipVisible}
+          />
+        </div>
 
         {isVisible && !isResizing && !isDragging && (
           <button

--- a/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegister/WorkCardRegister.tsx
@@ -97,22 +97,6 @@ const WorkCardRegister = ({
         onMouseEnter={show}
         onMouseLeave={hide}
       >
-        {/* {isToolTipVisible && (
-          <ToolTip
-            direction={'Top'}
-            content={
-              <div css={S.WorkCardToolTip}>
-                <div css={S.WorkCardToolTipContent}>
-                  <div css={S.WorkCardToolTipTitle}>{block.workName}</div>
-                  <div css={S.WorkCardToolTipCropName}>{block.cropName}</div>
-                </div>
-                <div css={S.WorkCardToolTipTime}>{block.workTime}</div>
-              </div>
-            }
-            type={'Default'}
-            offset={80}
-          />
-        )} */}
         {/* 왼쪽 리사이징 핸들 */}
         {!isDragging && onResize && (
           <div

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.style.ts
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.style.ts
@@ -8,6 +8,7 @@ import type { CropNameType } from '@/types/crop.type';
 import { FlexStyles } from '@/styles/commonStyles';
 
 const WorkCardContent = css`
+  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: row;
@@ -40,6 +41,7 @@ const WorkCardTitle = css`
   ${Typography.Body_S_400}
   color: ${Assets.Text.WorkCard.Default.Headline};
   display: block;
+  flex: 1 1 auto;
   min-width: 0;
   width: 100%;
   white-space: nowrap;
@@ -50,13 +52,20 @@ const WorkCardTitle = css`
 const WorkCardCropName = css`
   ${Typography.Caption_S}
   color: ${Assets.Text.WorkCard.Default.Headline};
-  min-width: 50px;
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const WorkCardTime = css`
   ${Typography.Caption_S}
   color: ${Assets.Text.WorkCard.Default.Body};
   display: block;
+  flex: 1 1 auto;
   min-width: 0;
   width: 100%;
   white-space: nowrap;

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
@@ -29,7 +29,7 @@ const WorkCardRegisterContent = ({
 
   return (
     <div css={S.WorkCardContent} ref={anchorRef}>
-      {width && width < 145 && isToolTipVisible && (
+      {width < 145 && isToolTipVisible && (
         <PortalToolTip
           anchorRef={anchorRef}
           direction={'Top'}
@@ -53,12 +53,12 @@ const WorkCardRegisterContent = ({
       <div css={S.WorkCardColorBar(cropName as CropNameType)} />
       <div css={S.WorkCardInfo}>
         <div css={S.WorkCardContentWrapper}>
-          {width && width > 80 && (
+          {width > 80 && (
             <div css={[S.WorkCardTitle, isCompleted && S.CompletedTextStyle]}>
               {workName}
             </div>
           )}
-          {width && width > 120 && (
+          {width > 120 && (
             <div
               css={[S.WorkCardCropName, isCompleted && S.CompletedTextStyle]}
             >
@@ -66,7 +66,7 @@ const WorkCardRegisterContent = ({
             </div>
           )}
         </div>
-        {width && width > 80 && (
+        {width > 80 && (
           <div css={[S.WorkCardTime, isCompleted && S.CompletedTextStyle]}>
             {workTime}
           </div>

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
@@ -1,9 +1,8 @@
-import ToolTip from '@/components/toolTip/ToolTip';
 import S from './WorkCardRegisterContent.style';
 import type { CropNameType } from '@/types/crop.type';
 import { WORK_CHIP_TYPES, type WorkChipType } from '@/types/workChip.type';
 import WorkCardRegisterS from '../workCardRegister/WorkCardRegister.style';
-import PortalComponent from '@/components/common/PortalComponent';
+import PortalToolTip from '@/components/common/PortalToolTip';
 import { useRef } from 'react';
 
 interface WorkCardRegisterProps {
@@ -31,28 +30,25 @@ const WorkCardRegisterContent = ({
   return (
     <div css={S.WorkCardContent} ref={anchorRef}>
       {width && width < 145 && isToolTipVisible && (
-        <PortalComponent anchorRef={anchorRef}>
-          <ToolTip
-            direction={'Top'}
-            content={
-              <div css={WorkCardRegisterS.WorkCardToolTip}>
-                <div css={WorkCardRegisterS.WorkCardToolTipContent}>
-                  <div css={WorkCardRegisterS.WorkCardToolTipTitle}>
-                    {workName}
-                  </div>
-                  <div css={WorkCardRegisterS.WorkCardToolTipCropName}>
-                    {cropName}
-                  </div>
+        <PortalToolTip
+          anchorRef={anchorRef}
+          direction={'Top'}
+          content={
+            <div css={WorkCardRegisterS.WorkCardToolTip}>
+              <div css={WorkCardRegisterS.WorkCardToolTipContent}>
+                <div css={WorkCardRegisterS.WorkCardToolTipTitle}>
+                  {workName}
                 </div>
-                <div css={WorkCardRegisterS.WorkCardToolTipTime}>
-                  {workTime}
+                <div css={WorkCardRegisterS.WorkCardToolTipCropName}>
+                  {cropName}
                 </div>
               </div>
-            }
-            type={'Default'}
-            offset={80}
-          />
-        </PortalComponent>
+              <div css={WorkCardRegisterS.WorkCardToolTipTime}>{workTime}</div>
+            </div>
+          }
+          type={'Default'}
+          offset={80}
+        />
       )}
       <div css={S.WorkCardColorBar(cropName as CropNameType)} />
       <div css={S.WorkCardInfo}>

--- a/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
+++ b/frontend/src/pages/homePage/components/workCardRegisterContent/WorkCardRegisterContent.tsx
@@ -1,6 +1,10 @@
+import ToolTip from '@/components/toolTip/ToolTip';
 import S from './WorkCardRegisterContent.style';
 import type { CropNameType } from '@/types/crop.type';
 import { WORK_CHIP_TYPES, type WorkChipType } from '@/types/workChip.type';
+import WorkCardRegisterS from '../workCardRegister/WorkCardRegister.style';
+import PortalComponent from '@/components/common/PortalComponent';
+import { useRef } from 'react';
 
 interface WorkCardRegisterProps {
   id?: number;
@@ -9,6 +13,7 @@ interface WorkCardRegisterProps {
   workTime: string;
   width?: number;
   status?: WorkChipType;
+  isToolTipVisible?: boolean;
 }
 
 const WorkCardRegisterContent = ({
@@ -17,11 +22,38 @@ const WorkCardRegisterContent = ({
   workName,
   workTime,
   status = WORK_CHIP_TYPES.INCOMPLETED,
+  isToolTipVisible = false,
 }: WorkCardRegisterProps) => {
   const isCompleted = status === WORK_CHIP_TYPES.COMPLETED;
 
+  const anchorRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div css={S.WorkCardContent}>
+    <div css={S.WorkCardContent} ref={anchorRef}>
+      {width && width < 145 && isToolTipVisible && (
+        <PortalComponent anchorRef={anchorRef}>
+          <ToolTip
+            direction={'Top'}
+            content={
+              <div css={WorkCardRegisterS.WorkCardToolTip}>
+                <div css={WorkCardRegisterS.WorkCardToolTipContent}>
+                  <div css={WorkCardRegisterS.WorkCardToolTipTitle}>
+                    {workName}
+                  </div>
+                  <div css={WorkCardRegisterS.WorkCardToolTipCropName}>
+                    {cropName}
+                  </div>
+                </div>
+                <div css={WorkCardRegisterS.WorkCardToolTipTime}>
+                  {workTime}
+                </div>
+              </div>
+            }
+            type={'Default'}
+            offset={80}
+          />
+        </PortalComponent>
+      )}
       <div css={S.WorkCardColorBar(cropName as CropNameType)} />
       <div css={S.WorkCardInfo}>
         <div css={S.WorkCardContentWrapper}>

--- a/frontend/src/pages/homePage/utils/work/getInitialWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/work/getInitialWorkBlocks.ts
@@ -1,12 +1,17 @@
 import type { CropNameType } from '@/types/crop.type';
 import type { GetMyWorksOfTodayResponse } from '@/types/openapiGenerator';
 import { sortWorkBlocks } from '@/pages/homePage/utils/work/sortWorkBlocks';
+import dayjs from 'dayjs';
 
 const getInitialWorkBlocks = (
   todayWorkScheduleData: GetMyWorksOfTodayResponse[]
 ) => {
+  //현재 시 보다 늦게 끝나는 작업 일정만 렌더링
+  const filteredWorkBlocks = todayWorkScheduleData.filter(work =>
+    dayjs(work.endTime).isAfter(dayjs().set('minute', 0))
+  );
   // WorkBlockType 형식으로 변환
-  const processedWorkBlocks = todayWorkScheduleData.map(work => ({
+  const processedWorkBlocks = filteredWorkBlocks.map(work => ({
     id: work.myWorkId ?? 0,
     cropName: work.myCropName as CropNameType,
     workName: work.myWorkName ?? '',


### PR DESCRIPTION
## 📌 연관된 이슈

- close #473

---

## 📝작업 내용

- 현재보다 이전 시간에 작업하기로 등록된 작업일정의 경우 작업 정보 텍스트를 맨 오른쪽에 뜨게 하고 마우스 호버 시 전체 텍스트를 확인할 수 있도록 구현했습니다
- 구현되어있는 ToolTip 컴포넌트를 감싸서 createPortal로 적용할 수 있는 컴포넌트인 PortalToolTip을 구현했습니다

---

### 스크린샷 (선택)
<img width="431" height="340" alt="스크린샷 2025-08-22 오전 9 00 33" src="https://github.com/user-attachments/assets/6306f556-1794-4f62-a427-5197f1262a6e" />


스크린샷에서 현재 시간은 서버 문제때문에 안뜨고 있어여

---

## 💬리뷰 요구사항

overflow hidden때문에 잘려서 createPortal썼습니당

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)