### PR TITLE
[Hotfix] Batch 프로젝트와 api server 프로젝트 간 entity 불일치로 인한 오류 해결

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/WeatherRisk.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/WeatherRisk.java
@@ -27,7 +27,6 @@ public class WeatherRisk {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long weatherRiskId;
-    private LocalDate fcstDate; //지워야 함
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     @Column(name = "nx")

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
@@ -101,7 +101,6 @@ class WeatherBriefingTest {
         final var to = now.plusHours(2);
         final WeatherRisk r1 = WeatherRisk.builder()
                 .weatherRiskId(1L)
-                .fcstDate(BASE.toLocalDate())
                 .startTime(from.withMinute(55))
                 .endTime(to.withMinute(57))
                 .nx(11)
@@ -111,7 +110,6 @@ class WeatherBriefingTest {
                 .build();
         final WeatherRisk r2 = WeatherRisk.builder()
                 .weatherRiskId(1L)
-                .fcstDate(BASE.toLocalDate())
                 .startTime(from.withMinute(8))
                 .endTime(to.withMinute(8))
                 .nx(11)


### PR DESCRIPTION
## 📌 연관된 이슈

- close #481 

---

## 📝작업 내용

Batch 프로젝트에서는 WeatherRisk 엔티티에 fcst_date 필드가 없어서 batch Job이 동작하면서 RDS의 테이블에 해당 컬럼이 지워진 것 같습니다.
그런데 API Server에서는 WeatherRisk에 fcst_date 필드가 남아있어서 엔티티를 읽을 수 없다는 500 error가 발생했습니다.
일단은 임시방편으로 RDS의 WeatherRisk에 fcst_date 컬럼을 추가하여 해결했습니다. 

1. api server 프로젝트의 WeatherRisk 엔티티에서 fcst_date 필드를 지웠습니다. 

---

## 💬리뷰 요구사항

제가 확인하긴 했는데 다른 엔티티도 동일한지 확인해주시면 감사하겠습니다. 😁

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)