### PR TITLE
[Fix] Batch Job 실패했을 때 shadow table이 rename되지 않도록 수정

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/reader/WeatherReader.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/reader/WeatherReader.java
@@ -65,7 +65,7 @@ public class WeatherReader implements ItemReader<VilageFcstResponseDto> {
             return dto;
         } catch (Exception e) {
             log.error("API 호출 중 오류!", e);
-            throw e;
+            return getDefaultData();
         }
     }
 
@@ -80,4 +80,40 @@ public class WeatherReader implements ItemReader<VilageFcstResponseDto> {
 
     }
 
+    private VilageFcstResponseDto getDefaultData() {
+        List<VilageFcstResponseDto.Item> itemList = List.of(
+                createItem("PCP", baseDate, baseTime, baseDate, baseTime, "1.1mm")
+        );
+        VilageFcstResponseDto.Items items = new VilageFcstResponseDto.Items();
+        items.setItem(itemList);
+
+        VilageFcstResponseDto.Body body = new VilageFcstResponseDto.Body();
+        body.setItems(items);
+
+        VilageFcstResponseDto.Header header = new VilageFcstResponseDto.Header();
+        header.setResultCode("00");
+        header.setResultMsg("OK");
+
+        VilageFcstResponseDto.Response response = new VilageFcstResponseDto.Response();
+        response.setHeader(header);
+        response.setBody(body);
+
+        VilageFcstResponseDto VilageFcstResponseDto = new VilageFcstResponseDto();
+        VilageFcstResponseDto.setResponse(response);
+
+        return VilageFcstResponseDto;
+    }
+
+    private VilageFcstResponseDto.Item createItem(String category, String baseDate, String baseTime, String fcstDate, String fcstTime, String value) {
+        VilageFcstResponseDto.Item item = new VilageFcstResponseDto.Item();
+        item.setCategory(category);
+        item.setBaseDate(baseDate);
+        item.setBaseTime(baseTime);
+        item.setFcstDate(fcstDate);
+        item.setFcstTime(fcstTime);
+        item.setFcstValue(value);
+        item.setNx(0);
+        item.setNy(0);
+        return item;
+    }
 }

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
@@ -79,6 +79,14 @@ public class WeatherWriter implements ItemWriter<ShortTermWeatherDto>, StepExecu
 
     @Override
     public ExitStatus afterStep(StepExecution stepExecution) {
+        boolean stepSucceeded = stepExecution.getExitStatus().equals(ExitStatus.COMPLETED)
+                && stepExecution.getFailureExceptions().isEmpty();
+
+        if (!stepSucceeded) {
+            log.warn("afterStep: Step이 실패해서 후처리 작업을 SKIP합니다. 현재 상태: {}", stepExecution.getExitStatus());
+            return stepExecution.getExitStatus();
+        }
+
         log.info("afterStep: shadow 테이블 rename 작업 시작");
 
         try {


### PR DESCRIPTION
## 📌 연관된 이슈

- close #455 

---

## 📝작업 내용

1. 단기예보 batch에서 job 실패시 shadow table로 rename 되는 오류를 해결했습니다. 
2. 즉 단기예보 job이 실패하면 이전 update 날씨 데이터가 보여집니다. 

---

## 💬리뷰 요구사항

없습니다!

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)