### PR TITLE
[Hofix] 기상 리스크 조회 API에서 24시간 이후의 리스크가 응답되는 오류 해결

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/util/WeatherRiskIntervalMerger.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/util/WeatherRiskIntervalMerger.java
@@ -54,6 +54,8 @@ public class WeatherRiskIntervalMerger {
         if(end.isBefore(now)) return;
         if(start.isBefore(now)) start = now;
 
+        if(end.isAfter(now)) end = now;
+
         String s = String.format("%02d", start.getHour());
         String e = String.format("%02d", end.getHour());
         if (!merged.isEmpty()) {


### PR DESCRIPTION
## 📌 연관된 이슈

- close #492 

---

## 📝작업 내용

1. 기상 리스크 조회 API에서 24시간 이후의 리스크가 응답되는 오류 해결했습니다. 

---

## 💬리뷰 요구사항

딱히 없습니다!

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)