### PR TITLE
[Fix] 농작업 추천 시 단기 예보 정렬 오류 해결

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/util/WorkScheduleCalculator.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/util/WorkScheduleCalculator.java
@@ -29,9 +29,8 @@ public class WorkScheduleCalculator {
             LocalDateTime requestDateTime
     ) {
         List<ShortTermWeatherForecast> sortedForecasts = forecasts.stream()
-                .filter(forecast -> forecast.getFcstTime().isAfter(requestDateTime.minusHours(1)) && forecast.getFcstTime().isBefore(requestDateTime.minusHours(1).plusDays(1)))
+                .filter(forecast -> forecast.getFcstTime().isAfter(requestDateTime.minusHours(1)) && forecast.getFcstTime().isBefore(requestDateTime.minusHours(2).plusDays(1)))
                 .sorted(Comparator.comparing(ShortTermWeatherForecast::getFcstTime))
-                .filter(f -> f.getFcstTime().isAfter(requestDateTime))
                 .toList();
 
         List<RecommendWorksResponse.RecommendationDurations> durations =


### PR DESCRIPTION
## 📌 연관된 이슈

- close #500

---

## 📝작업 내용

1. 드디어 원인을 발견했습니다....
`ShortTermWeatherForecast`를 시간 순으로 정렬 후에 추천 시간대를 구성하는 로직인데, `fcstTime`이 hour(int) 로직을 제대로 변경하지 않아서 정렬이 다음과 같이 hour 기준으로만 되고 있었습니다.

```java
"2025-08-24T01:00"
"2025-08-25T01:00"
"2025-08-24T02:00"
"2025-08-25T02:00"
```

이를 날짜, 시간을 모두 고려하여 정렬하도록 고쳤습니다.

2. 추천 시간대가 현재 시각부터 23시간 이후 내로 구성되도록 아래와 같이 필터링했습니다.
```java
List<ShortTermWeatherForecast> sortedForecasts = forecasts.stream()
                .filter(forecast -> forecast.getFcstTime().isAfter(requestDateTime.minusHours(1)) && forecast.getFcstTime().isBefore(requestDateTime.minusHours(2).plusDays(1)))
```

예를 들어 **2025년 8월 24일 2시 14분**에 요청을 보낸다면 forecast의 FcstTime이
**2025년 8월 24일 1시 14분** (requestDateTime.minusHours(1))보다 이후이고, **2025년 8월 24일 23시 14분** (requestDateTime.minusHours(2).plusDays(1))) 보다 이전인 forecast 들만 사용하게 됩니다.

```plain text
2025년 8월 24일 2시
2025년 8월 24일 3시
...
2025년 8월 24일 23시
```

종료 시각에서 _**2시간을 빼고**_ 1일을 더하는 이유는 추천 시간대는 조건을 만족하는 시간에서 1시간을 더하여 구성되기 때문입니다.
- 예를 들어 **n월 n일 17시**에 기상 조건을 만족하면 추천 시간대는  `a ~ 18시`로 구성됩니다.


---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)