### PR TITLE
[Feat] 작업 추가/삭제 시 재정렬 및 애니메이팅 추가

### DIFF
--- a/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.style.ts
+++ b/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.style.ts
@@ -23,6 +23,9 @@ const RegisterWorkContainer = css`
 const TextBoxTitle = css`
   ${Typography.Subtitle_700}
   color: ${Assets.Text.Global.Headline};
+  display: flex;
+  align-items: center;
+  gap: 4px;
 `;
 
 const TextBoxDescription = css`
@@ -61,6 +64,14 @@ const BtnCreateWorkContainer = css`
   height: 52px;
 `;
 
+const IconContainer = css`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+
 export default {
   RegisterWorkContainer,
   TextBoxTitle,
@@ -69,4 +80,5 @@ export default {
   BtnBox,
   BtnSelectChipContainer,
   BtnCreateWorkContainer,
+  IconContainer,
 };

--- a/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
@@ -6,10 +6,11 @@ import type {
   MyCropResponse,
   RecommendedWorksResponse,
 } from '@/types/openapiGenerator';
-import ToolTip from '@/components/toolTip/ToolTip';
+import PortalToolTip from '@/components/common/PortalToolTip';
 import { TOOLTIP_DIRECTIONS, TOOLTIP_TYPES } from '@/types/tooltip.type';
 import { IC24InfoIcon } from '@/assets/icons/flat';
 import useVisibility from '@/hooks/useVisibility';
+import { useRef } from 'react';
 
 interface RegisterWorkContainerProps {
   recommendedWorks: RecommendedWorksResponse[];
@@ -32,6 +33,7 @@ const RegisterWorkContainer = ({
   setSelectedRecommendedWork,
 }: RegisterWorkContainerProps) => {
   const { isVisible, show, hide } = useVisibility();
+  const iconRef = useRef<HTMLDivElement>(null);
 
   return (
     <div css={S.RegisterWorkContainer}>
@@ -57,10 +59,16 @@ const RegisterWorkContainer = ({
               onClick={() => handleCropClick(crop)}
             />
           ))}
-          <div css={S.IconContainer} onMouseEnter={show} onMouseLeave={hide}>
+          <div
+            css={S.IconContainer}
+            ref={iconRef}
+            onMouseEnter={show}
+            onMouseLeave={hide}
+          >
             <IC24InfoIcon width={24} height={24} />
             {isVisible && (
-              <ToolTip
+              <PortalToolTip
+                anchorRef={iconRef}
                 direction={TOOLTIP_DIRECTIONS.RIGHT}
                 content={
                   <div>

--- a/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
@@ -6,10 +6,10 @@ import type {
   MyCropResponse,
   RecommendedWorksResponse,
 } from '@/types/openapiGenerator';
-import { TOOLTIP_DIRECTIONS, TOOLTIP_TYPES } from '@/types/tooltip.type';
 import ToolTip from '@/components/toolTip/ToolTip';
-import useVisibility from '@/hooks/useVisibility';
+import { TOOLTIP_DIRECTIONS, TOOLTIP_TYPES } from '@/types/tooltip.type';
 import { IC24InfoIcon } from '@/assets/icons/flat';
+import useVisibility from '@/hooks/useVisibility';
 
 interface RegisterWorkContainerProps {
   recommendedWorks: RecommendedWorksResponse[];
@@ -36,19 +36,7 @@ const RegisterWorkContainer = ({
   return (
     <div css={S.RegisterWorkContainer}>
       <div css={S.TextBox}>
-        <div css={S.TextBoxTitle}>
-          작업 일정 추천하기{' '}
-          <div css={S.IconContainer} onMouseEnter={show} onMouseLeave={hide}>
-            <IC24InfoIcon width={24} height={24} />
-            {isVisible && (
-              <ToolTip
-                direction={TOOLTIP_DIRECTIONS.RIGHT}
-                content={<div>작업 일정을 드래그하여 추가할 수 있습니다.</div>}
-                type={TOOLTIP_TYPES.DEFAULT}
-              />
-            )}
-          </div>
-        </div>
+        <div css={S.TextBoxTitle}>작업 일정 추천하기 </div>
         <div css={S.TextBoxDescription}>
           과실이 크게 자라는 지금, 기상 상황에 따라 이런 작업을 추천 드려요!
         </div>
@@ -69,6 +57,21 @@ const RegisterWorkContainer = ({
               onClick={() => handleCropClick(crop)}
             />
           ))}
+          <div css={S.IconContainer} onMouseEnter={show} onMouseLeave={hide}>
+            <IC24InfoIcon width={24} height={24} />
+            {isVisible && (
+              <ToolTip
+                direction={TOOLTIP_DIRECTIONS.RIGHT}
+                content={
+                  <div>
+                    작물을 선택하고 추천 작업 일정을 드래그하여 추가할 수
+                    있습니다.
+                  </div>
+                }
+                type={TOOLTIP_TYPES.DEFAULT}
+              />
+            )}
+          </div>
         </div>
         <div css={S.BtnCreateWorkContainer}>
           {recommendedWorks.map(work => (

--- a/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/registerWorkContainer/RegisterWorkContainer.tsx
@@ -6,6 +6,10 @@ import type {
   MyCropResponse,
   RecommendedWorksResponse,
 } from '@/types/openapiGenerator';
+import { TOOLTIP_DIRECTIONS, TOOLTIP_TYPES } from '@/types/tooltip.type';
+import ToolTip from '@/components/toolTip/ToolTip';
+import useVisibility from '@/hooks/useVisibility';
+import { IC24InfoIcon } from '@/assets/icons/flat';
 
 interface RegisterWorkContainerProps {
   recommendedWorks: RecommendedWorksResponse[];
@@ -27,10 +31,24 @@ const RegisterWorkContainer = ({
   handleCreateWork,
   setSelectedRecommendedWork,
 }: RegisterWorkContainerProps) => {
+  const { isVisible, show, hide } = useVisibility();
+
   return (
     <div css={S.RegisterWorkContainer}>
       <div css={S.TextBox}>
-        <div css={S.TextBoxTitle}>작업 일정 추천하기</div>
+        <div css={S.TextBoxTitle}>
+          작업 일정 추천하기{' '}
+          <div css={S.IconContainer} onMouseEnter={show} onMouseLeave={hide}>
+            <IC24InfoIcon width={24} height={24} />
+            {isVisible && (
+              <ToolTip
+                direction={TOOLTIP_DIRECTIONS.RIGHT}
+                content={<div>작업 일정을 드래그하여 추가할 수 있습니다.</div>}
+                type={TOOLTIP_TYPES.DEFAULT}
+              />
+            )}
+          </div>
+        </div>
         <div css={S.TextBoxDescription}>
           과실이 크게 자라는 지금, 기상 상황에 따라 이런 작업을 추천 드려요!
         </div>

--- a/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
+++ b/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
@@ -55,14 +55,10 @@ const DragIcon = css`
   height: 24px;
 `;
 
-const workCell = (
-  type: WorkCellType,
-  status: WorkCellStatus,
-  isHovered: boolean
-) => css`
+const workCell = (type: WorkCellType, status: WorkCellStatus) => css`
   ${baseStyle}
   ${borderRadius[type]}
-  ${isHovered ? WorkCellStatusStyle.Hover : WorkCellStatusStyle[status]}
+  ${WorkCellStatusStyle[status]}
 
   &:active {
     ${WorkCellStatusStyle.Active}

--- a/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
+++ b/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
@@ -30,7 +30,7 @@ const WorkCellStatusStyle = {
 };
 
 const baseStyle = css`
-  width: 92px;
+  width: 96px;
   height: 176px;
   transition: background-color 0.1s ease-in-out;
   position: relative;

--- a/frontend/src/pages/homePage/components/workCell/WorkCell.tsx
+++ b/frontend/src/pages/homePage/components/workCell/WorkCell.tsx
@@ -1,8 +1,5 @@
-import { useState } from 'react';
-import { IC24DragIcon } from '@/assets/icons/flat';
 import S from './WorkCell.style';
 import type { WorkCellType, WorkCellStatus } from '@/types/workCell.type';
-import { useTheme } from '@emotion/react';
 
 interface WorkCellProps {
   type: WorkCellType;
@@ -10,29 +7,7 @@ interface WorkCellProps {
 }
 
 const WorkCell = ({ type, status }: WorkCellProps) => {
-  const [isHovered, setIsHovered] = useState(false);
-  const theme = useTheme();
-
-  return (
-    <div
-      css={S.workCell(type, status, isHovered)}
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      {isHovered && (
-        <div css={S.HoverCell(theme)}>
-          <div css={S.DragIcon}>
-            <IC24DragIcon
-              width={24}
-              height={24}
-              fill={theme.ColorPrimary.B300}
-            />
-          </div>
-          <p>작업 일정을{'\n'}드래그 하세요</p>
-        </div>
-      )}
-    </div>
-  );
+  return <div css={S.workCell(type, status)} />;
 };
 
 export default WorkCell;

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
@@ -4,10 +4,10 @@ import { WORK_TIME_DEFAULT_X_COORDINATE } from '@/constants/workTimePx';
 const WorkCellsContainerWrapper = css`
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: 4px;
   align-items: center;
   min-width: max-content;
-  padding: 16px ${WORK_TIME_DEFAULT_X_COORDINATE}px 16px 12px;
+  padding: 16px 12px 16px ${WORK_TIME_DEFAULT_X_COORDINATE}px;
   position: relative;
 `;
 

--- a/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
+++ b/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
@@ -8,7 +8,6 @@ import type {
 import { getYCoordinate, X_PX_PER_HOUR } from '@/constants/workTimeCoordinate';
 import { findCollisionFreePosition } from '@/components/dnd/utils/collisionUtils';
 import updateWorkTime from '@/pages/homePage/utils/work/updateWorkTime';
-import { postMyWork } from '@/apis/myWork.api';
 import { snapToGrid } from '@/utils/snapToGrid';
 
 interface UseCreateWorkBlockReturn {
@@ -22,7 +21,11 @@ interface UseCreateWorkBlockReturn {
 interface UseCreateWorkBlockProps {
   containerRef: React.RefObject<HTMLDivElement> | null;
   scrollOffset: number;
-  addWorkBlock: (workBlock: WorkBlockType) => void;
+  addWorkBlock: (
+    workBlock: WorkBlockType,
+    myCropId: number,
+    recommendedWorkId: number
+  ) => void;
   workBlocks: WorkBlockType[];
 }
 
@@ -96,17 +99,7 @@ export const useCreateWorkBlock = ({
           position: collisionFreePosition,
         };
 
-        // API 호출하여 새로운 작업 생성
-        const newWorkIdRes = await postMyWork({
-          startTime: newWorkBlock.startTime,
-          endTime: newWorkBlock.endTime,
-          myCropId: selectedCrop.myCropId,
-          recommendedWorkId: work.workId,
-        });
-
-        const newWorkId = newWorkIdRes.data.workId as number;
-
-        addWorkBlock({ ...newWorkBlock, id: newWorkId });
+        addWorkBlock(newWorkBlock, selectedCrop.myCropId!, work.workId!);
       } catch (error) {
         console.error('작업 블록 생성 실패:', error);
       }

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { WorkBlockType } from '@/types/workCard.type';
-import { getMyWorkOfToday, deleteMyWork } from '@/apis/myWork.api';
+import { getMyWorkOfToday, deleteMyWork, postMyWork } from '@/apis/myWork.api';
 import getInitialWorkBlocks from '@/pages/homePage/utils/work/getInitialWorkBlocks';
 
 const useWorkBlocks = () => {
@@ -18,8 +18,25 @@ const useWorkBlocks = () => {
     }
   }, []);
 
-  const addWorkBlock = (newWorkBlock: WorkBlockType) => {
-    setWorkBlocks(prev => [...prev, newWorkBlock]);
+  const addWorkBlock = async (
+    newWorkBlock: WorkBlockType,
+    myCropId: number,
+    recommendedWorkId: number
+  ) => {
+    try {
+      const newWorkIdRes = await postMyWork({
+        startTime: newWorkBlock.startTime,
+        endTime: newWorkBlock.endTime,
+        myCropId,
+        recommendedWorkId,
+      });
+
+      const newWorkId = newWorkIdRes.data.workId as number;
+
+      setWorkBlocks(prev => [...prev, { ...newWorkBlock, id: newWorkId }]);
+    } catch (error) {
+      console.error('작업 추가 실패', error);
+    }
   };
 
   const updateWorkBlocks = (updatedBlocks: WorkBlockType[]) => {

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -2,9 +2,13 @@ import { useEffect, useState } from 'react';
 import type { WorkBlockType } from '@/types/workCard.type';
 import { getMyWorkOfToday, deleteMyWork, postMyWork } from '@/apis/myWork.api';
 import getInitialWorkBlocks from '@/pages/homePage/utils/work/getInitialWorkBlocks';
+import useBlocksTransition from '@/components/dnd/hooks/useBlocksTransition';
+import { sortWorkBlocks } from '../../utils/work/sortWorkBlocks';
 
 const useWorkBlocks = () => {
   const [workBlocks, setWorkBlocks] = useState<WorkBlockType[]>([]);
+
+  const { animateBlocksTransition } = useBlocksTransition(setWorkBlocks);
 
   useEffect(() => {
     const fetchMyWorkOfToday = async () => {
@@ -33,7 +37,10 @@ const useWorkBlocks = () => {
 
       const newWorkId = newWorkIdRes.data.workId as number;
 
-      setWorkBlocks(prev => [...prev, { ...newWorkBlock, id: newWorkId }]);
+      animateBlocksTransition(
+        workBlocks,
+        sortWorkBlocks([...workBlocks, { ...newWorkBlock, id: newWorkId }])
+      );
     } catch (error) {
       console.error('작업 추가 실패', error);
     }
@@ -48,7 +55,10 @@ const useWorkBlocks = () => {
       await deleteMyWork({
         myWorkId: Number(id),
       });
-      setWorkBlocks(prev => prev.filter(block => block.id !== Number(id)));
+      animateBlocksTransition(
+        workBlocks,
+        sortWorkBlocks(workBlocks.filter(block => block.id !== Number(id)))
+      );
     } catch (error) {
       console.error('작업 삭제 실패', error);
     }

--- a/frontend/src/pages/myFarmPage/components/myCropInfo/MyCropInfo.tsx
+++ b/frontend/src/pages/myFarmPage/components/myCropInfo/MyCropInfo.tsx
@@ -24,9 +24,9 @@ const MyCropInfo = () => {
         title="내 작물 정보"
         Icon={<IC24InfoIcon width={24} height={24} />}
         toolTipContent={
-          <div>{`작물의 현재 생육 단계를\n확인할 수 있습니다`}</div>
+          <div>{`작물의 현재 생육 단계를 확인할 수 있습니다`}</div>
         }
-        toolTipDirection={TOOLTIP_DIRECTIONS.TOP}
+        toolTipDirection={TOOLTIP_DIRECTIONS.RIGHT}
       />
       <div css={S.CropInfoCardContainer}>
         {crops?.map(crop => (

--- a/frontend/src/pages/myFarmPage/components/myFarmHeader/MyFarmHeader.style.ts
+++ b/frontend/src/pages/myFarmPage/components/myFarmHeader/MyFarmHeader.style.ts
@@ -20,6 +20,7 @@ const IconContainer = css`
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 `;
 
 const Tooltip = css`


### PR DESCRIPTION
## 📌 연관된 이슈

- close #493

---

## 📝작업 내용

- 원래 작업/추가 시 재정렬과 애니메이팅 블록 이동이 안되었는데 되도록 추가했습니다
- 작업 블록의 시간대가 미묘하게 안맞아서 수정했습니다
- 내농장 툴팁 방향 수정
- WorkCell에 hover 시 색이 변하고 작업일정을 드래그해서 추가하라는 문구가 떴는데, Hover 스타일이 들어가니 해당 공간을 클릭해야할 것같다는 피드백이 있어 hover을 삭제하고 안내 문구 툴팁을 추가했습니다 

- WorkCell 간 간격이 크니 시간이 정확히 맞지 않는 것 처럼 보여 gap을 줄이고 width를 늘렸습니다
<img width="360" height="175" alt="스크린샷 2025-08-24 오후 3 14 52" src="https://github.com/user-attachments/assets/77ab8794-1816-4423-92dd-1ea0d0915486" />

수정 전: WorkCell의 밖으로 넘어가야 20시에 도달

<img width="337" height="135" alt="스크린샷 2025-08-24 오후 3 13 17" src="https://github.com/user-attachments/assets/e5eff710-41bd-45b4-b63e-aef6eca4b415" />

수정 후: 17시에 시작해서 20시에 끝나는 게 그리드에 거의 맞는 것 처럼 보임

---

### 스크린샷 (선택)

#### 정렬 애니메이션
https://github.com/user-attachments/assets/3cb4a2ea-d604-4aab-819c-ce57f6d312bf

정렬 애니메이션 추가 후, workCell 수정 전

<img width="1356" height="453" alt="스크린샷 2025-08-24 오후 3 08 43" src="https://github.com/user-attachments/assets/3167bbd4-8161-4a5c-aed9-f37d4462141d" />

WorkCell 수정 후, 툴팁 추가

<img width="478" height="171" alt="스크린샷 2025-08-24 오후 3 17 38" src="https://github.com/user-attachments/assets/7166a145-bb4f-46ef-8690-87636fd86c42" />
내농장 툴팁 방향 수정
---

## 💬리뷰 요구사항

useWorkBlocks 훅 내에 data fetch, 상태 관리, animating이 혼재되어있는데 어떻게 관심사 분리를 할 수 있을 지 고민입니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)