### PR TITLE
[Feat] 농작업 상태를 다시 `INCOMPLETED`로 변경하면 집계에서 제외되도록 구현

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/entity/WorkActivityFact.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/entity/WorkActivityFact.java
@@ -3,7 +3,6 @@ package com.imsnacks.Nyeoreumnagi.work.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Immutable;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.io.Serializable;
@@ -25,8 +24,11 @@ public class WorkActivityFact {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    public static WorkActivityFact of(LocalDate day, Long workId, String tile, Long memberId) {
-        return new WorkActivityFact(new Key(day, workId, tile, memberId), null);
+    @Enumerated(EnumType.STRING)
+    private WorkStatus workStatus;
+
+    public static WorkActivityFact of(LocalDate day, Long workId, String tile, WorkStatus workStatus, Long memberId) {
+        return new WorkActivityFact(new Key(day, workId, tile, memberId), null, workStatus);
     }
 
     @Embeddable

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEvent.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEvent.java
@@ -1,6 +1,8 @@
 package com.imsnacks.Nyeoreumnagi.work.event;
 
+import com.imsnacks.Nyeoreumnagi.work.entity.WorkStatus;
+
 import java.time.LocalDate;
 
 public record MyWorkCompletedEvent(long memberId, long workId,
-                                   double latitude, double longitude, LocalDate date) {}
+                                   double latitude, double longitude, WorkStatus workStatus, LocalDate date) {}

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEventListener.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEventListener.java
@@ -25,6 +25,7 @@ public class MyWorkCompletedEventListener {
                 event.date(),
                 event.workId(),
                 geohash,
+                event.workStatus().toString(),
                 event.memberId()
         );
     }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/WorkActivityFactRepository.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/repository/WorkActivityFactRepository.java
@@ -15,24 +15,28 @@ import static com.imsnacks.Nyeoreumnagi.work.entity.WorkActivityFact.*;
 public interface WorkActivityFactRepository extends JpaRepository<WorkActivityFact, Key> {
     @Modifying
     @Query(value = """
-      INSERT IGNORE INTO work_activity_fact(day, work_id, tile, member_id, created_at)
-      VALUES (:day, :workId, :tile, :memberId, now())
-      """, nativeQuery = true)
-    int insertIgnore(@org.springframework.data.repository.query.Param("day") java.time.LocalDate day,
-                     @org.springframework.data.repository.query.Param("workId") long workId,
-                     @org.springframework.data.repository.query.Param("tile") String tile,
-                     @org.springframework.data.repository.query.Param("memberId") long memberId);
+            INSERT INTO work_activity_fact(day, work_id, tile, member_id, work_status, created_at)
+            VALUES (:day, :workId, :tile, :memberId, :workStatus, now())
+            ON DUPLICATE KEY UPDATE
+            work_status = VALUES(work_status)
+            """, nativeQuery = true)
+    int insertIgnore(@Param("day") java.time.LocalDate day,
+                     @Param("workId") long workId,
+                     @Param("tile") String tile,
+                     @Param("workStatus") String workStatus,
+                     @Param("memberId") long memberId);
 
 
     // (on-read) 최근 3일 + 타일 집합에서 distinct member 후보 조회
     @Query(value = """
-        SELECT DISTINCT member_id
-        FROM work_activity_fact
-        WHERE work_id = :workId
-          AND day IN (:d0,:d1,:d2)
-          AND tile IN (:tiles)
-          AND member_id <> :currentMemberId
-        """, nativeQuery = true)
+            SELECT DISTINCT member_id
+            FROM work_activity_fact
+            WHERE work_id = :workId
+              AND day IN (:d0,:d1,:d2)
+              AND tile IN (:tiles)
+              AND work_status = 'COMPLETED'
+              AND member_id <> :currentMemberId
+            """, nativeQuery = true)
     List<Long> findCandidateMemberIds(@Param("workId") long workId,
                                       @Param("currentMemberId") long currentMemberId,
                                       @Param("d0") LocalDate d0,

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/MyWorkService.java
@@ -176,22 +176,22 @@ public class MyWorkService {
     }
 
     @Transactional
-    public void updateMyWorkStatus(UpdateMyWorkStatusRequest request, long memberId){
+    public void updateMyWorkStatus(UpdateMyWorkStatusRequest request, long memberId) {
         Farm farm = farmRepository.findByMember_Id(memberId).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
         MyWork myWork = myWorkRepository.findById(request.myWorkId()).orElseThrow(() -> new WorkException(MY_WORK_NOT_FOUND));
 
-        if(!myWork.getMember().getId().equals(memberId)){
+        if (!myWork.getMember().getId().equals(memberId)) {
             throw new WorkException(MY_WORK_NOT_FOUND);
         }
 
-        if (request.status().equals(COMPLETED)) {
-            publisher.publishEvent(new MyWorkCompletedEvent(myWork.getMember().getId(),
-                    myWork.getRecommendedWork().getId(),
-                    farm.getLocation().getY(),
-                    farm.getLocation().getX(),
-                    LocalDate.now()));
-
-        }
         myWork.setWorkStatus(request.status());
+
+        publisher.publishEvent(new MyWorkCompletedEvent(myWork.getMember().getId(),
+                myWork.getRecommendedWork().getId(),
+                farm.getLocation().getY(),
+                farm.getLocation().getX(),
+                myWork.getWorkStatus(),
+                LocalDate.now()));
+
     }
 }

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/NearbyAggregationService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/NearbyAggregationService.java
@@ -30,7 +30,6 @@ public class NearbyAggregationService {
 
         Set<String> tiles = GeoUtil.tilesForRadiusKm(centerLat, centerLon, 5.0);
 
-
         List<Long> candidateIds = factRepo.findCandidateMemberIds(workId, currentMemberId, d0, d1, d2, tiles);
 
         if (candidateIds.isEmpty()) return 0;
@@ -40,8 +39,8 @@ public class NearbyAggregationService {
 
         long count = locRows.stream()
                 .map(r -> new MemberLoc(((Number) r[0]).longValue(),
-                        ((Number) r[1]).doubleValue(), // lat
-                        ((Number) r[2]).doubleValue()  // lon
+                        ((Number) r[2]).doubleValue(), // lat
+                        ((Number) r[1]).doubleValue()  // lon
                 ))
                 .filter(loc -> haversineMeters(centerLat, centerLon, loc.lat(), loc.lon()) <= 5000.0)
                 .map(MemberLoc::memberId).distinct().count();

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/RecommendedWorkService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/service/RecommendedWorkService.java
@@ -85,10 +85,9 @@ public class RecommendedWorkService {
     }
 
     private long getNeighborCountForWork(long currentMemberId, long workId) {
-        // 내 기준점: 내 농장 위치
         Point loc = farmRepository.findByMember_Id(currentMemberId)
                 .orElseThrow()
-                .getLocation(); // x=lon, y=lat
+                .getLocation();
 
         double centerLat = loc.getY();
         double centerLon = loc.getX();

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/work/entity/WorkActivityFactTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/work/entity/WorkActivityFactTest.java
@@ -16,14 +16,16 @@ class WorkActivityFactTest {
         LocalDate day = LocalDate.of(2023, 10, 26);
         Long workId = 123L;
         String tile = "Sample Tile";
+        WorkStatus workStatus = WorkStatus.COMPLETED;
         Long memberId = 456L;
 
-        WorkActivityFact result = WorkActivityFact.of(day, workId, tile, memberId);
+        WorkActivityFact result = WorkActivityFact.of(day, workId, tile, workStatus, memberId);
 
         assertThat(result).isNotNull();
         assertThat(result.getId().getWorkId()).isEqualTo(workId);
         assertThat(result.getId().getDay()).isEqualTo(day);
         assertThat(result.getId().getTile()).isEqualTo(tile);
+        assertThat(result.getWorkStatus()).isEqualTo(workStatus);
         assertThat(result.getId().getMemberId()).isEqualTo(memberId);
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #528

---

## 📝작업 내용

1. 농작업 상태를 `COMPLETED` 로 변경할 때만 `WorkActivityFact` 테이블에 insert 했었습니다. 그러나 상태를 다시 `INCOMPLETED` 로 바꾸면 농작업 인원 집계에서 제외해야하기 때문에 `WorkActivityFact` 에 상태 필드를 추가하고 `insert ignore` 대신 같은 키 레코드가 존재하면 insert 대신 update 할 수 있도록 쿼리 메서드를 수정했습니다.

### 변경 전
```SQL
  INSERT IGNORE INTO work_activity_fact(day, work_id, tile, member_id, created_at)
      VALUES (:day, :workId, :tile, :memberId, now())
```

### 변경 후
```SQL
  INSERT INTO work_activity_fact(day, work_id, tile, member_id, work_status, created_at)
            VALUES (:day, :workId, :tile, :memberId, :workStatus, now())
            ON DUPLICATE KEY UPDATE
            work_status = VALUES(work_status)
```

2. 로컬과 배포 디비 모두 `Farm`의 `location` 필드가 위경도가 반대로 저장돼있었습니다. 아래 SQL로 일괄 수정했습니다.
```SQL
UPDATE farm
SET location = POINT(ST_Y(location), ST_X(location));
```

3. 농작업 추천 시 `COMPLETED` 인 농작업 인원만 집계할 수 있도록 개선했습니다. 
---

## 💬리뷰 요구사항

없습니다.

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)