### PR TITLE
[Fix] 기상 브리핑 메시지의 기상 특보 시작 시간 요건 변경

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
@@ -61,9 +61,13 @@ public final class Briefing {
         else return GOOD_EVENING_NO_RISK;
     }
 
-    public static String buildWeatherMsg(final WeatherRisk risk) {
-        final String from = getClockHourAsString(risk.getStartTime()); // <오전/오후> <1-12>시
-        final String to = getClockHourAsString(risk.getEndTime());
+    public static String buildWeatherMsg(LocalDateTime now, WeatherRisk risk) {
+        LocalDateTime start = risk.getStartTime();
+        LocalDateTime end = risk.getEndTime();
+        boolean isBeforeNow = start.isBefore(now);
+
+        final String from = getClockHourAsString(isBeforeNow ? now : start);
+        final String to = getClockHourAsString(end);
 
         final StringBuilder sb = new StringBuilder();
         sb.append(from).append(FROM_KOR).append(SPACE);

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/Briefing.java
@@ -64,9 +64,8 @@ public final class Briefing {
     public static String buildWeatherMsg(LocalDateTime now, WeatherRisk risk) {
         LocalDateTime start = risk.getStartTime();
         LocalDateTime end = risk.getEndTime();
-        boolean isBeforeNow = start.isBefore(now);
 
-        final String from = getClockHourAsString(isBeforeNow ? now : start);
+        final String from = getClockHourAsString(start.isBefore(now) ? now : start);
         final String to = getClockHourAsString(end);
 
         final StringBuilder sb = new StringBuilder();

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -169,7 +169,7 @@ public class WeatherService {
             return new GetWeatherBriefingResponse(false, briefing.buildNoRiskWelcomeMsg(now.getHour()), briefing.buildNoRiskWeatherMsg(memberId, now.getHour()));
         }
 
-        return new GetWeatherBriefingResponse(true, briefing.buildWelcomeMsg(now.getHour()), briefing.buildWeatherMsg(filteredRisk.get(0)));
+        return new GetWeatherBriefingResponse(true, briefing.buildWelcomeMsg(now.getHour()), briefing.buildWeatherMsg(now, filteredRisk.get(0)));
     }
 
     public GetSunRiseSetTimeResponse getSunRiseSetTime(final Long memberId) {

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
@@ -133,8 +133,24 @@ class WeatherBriefingTest {
                 .jobExecutionId(1L)
                 .build();
 
-        String actual = briefing.buildWeatherMsg(testRisk);
+        String actual = briefing.buildWeatherMsg(testTime, testRisk);
         String expected = "오후 9시부터 오후 2시까지 이상고온";
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    void 기상정보가_현시각_이전에_시작한_경우() {
+        LocalDateTime testTime = LocalDateTime.of(2025, 8, 23, 18, 42);
+        WeatherRisk testRisk = WeatherRisk.builder()
+                .startTime(testTime.withHour(15))
+                .endTime(testTime.plusDays(1).withHour(14))
+                .name(WeatherRiskType.ABNORMAL_HEAT)
+                .jobExecutionId(1L)
+                .build();
+
+        String actual = briefing.buildWeatherMsg(testTime, testRisk);
+        String expected = "오후 6시부터 오후 2시까지 이상고온";
+        assertThat(actual).isEqualTo(expected);
+    }
+
 }

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
@@ -1,46 +1,32 @@
 package com.imsnacks.Nyeoreumnagi.weather;
 
 import com.imsnacks.Nyeoreumnagi.common.enums.WeatherRiskType;
-import com.imsnacks.Nyeoreumnagi.member.entity.Farm;
 import com.imsnacks.Nyeoreumnagi.member.entity.Member;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberException;
 import com.imsnacks.Nyeoreumnagi.member.exception.MemberResponseStatus;
 import com.imsnacks.Nyeoreumnagi.member.repository.FarmRepository;
 import com.imsnacks.Nyeoreumnagi.member.repository.MemberRepository;
-import com.imsnacks.Nyeoreumnagi.weather.dto.response.GetWeatherBriefingResponse;
 import com.imsnacks.Nyeoreumnagi.weather.entity.WeatherRisk;
 import com.imsnacks.Nyeoreumnagi.weather.repository.DashboardTodayWeatherRepository;
 import com.imsnacks.Nyeoreumnagi.weather.repository.ShortTermWeatherForecastRepository;
 import com.imsnacks.Nyeoreumnagi.weather.repository.WeatherRiskRepository;
 import com.imsnacks.Nyeoreumnagi.weather.service.Briefing;
 import com.imsnacks.Nyeoreumnagi.weather.service.WeatherService;
-import com.imsnacks.Nyeoreumnagi.work.entity.Crop;
-import com.imsnacks.Nyeoreumnagi.work.entity.MyCrop;
 import com.imsnacks.Nyeoreumnagi.work.repository.MyCropRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
+++ b/backend/src/test/java/com/imsnacks/Nyeoreumnagi/weather/WeatherBriefingTest.java
@@ -65,6 +65,8 @@ class WeatherBriefingTest {
     @Mock
     private Random random;
 
+    Briefing briefing;
+
     @Test
     void 멤버가_없는_경우_예외_발생() {
         final long memberId = 42L;
@@ -119,5 +121,20 @@ class WeatherBriefingTest {
                 .build();
         final int actual = Briefing.RISK_COMPARATOR.compare(r1, r2);
         assertThat(actual).isEqualTo(1);
+    }
+
+    @Test
+    void 기상정보가_다음날까지_걸쳐있는_경우() {
+        LocalDateTime testTime = LocalDateTime.of(2025, 8, 23, 18, 42);
+        WeatherRisk testRisk = WeatherRisk.builder()
+                .startTime(testTime.withHour(21))
+                .endTime(testTime.plusDays(1).withHour(14))
+                .name(WeatherRiskType.ABNORMAL_HEAT)
+                .jobExecutionId(1L)
+                .build();
+
+        String actual = briefing.buildWeatherMsg(testRisk);
+        String expected = "오후 9시부터 오후 2시까지 이상고온";
+        assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- close #509 

---

## 📝작업 내용

**문제 상황 예시**
현재 시각: 17시 42분
브리핑에 표시할 기상 리스크 기간(WeatherRisk 레코드): 16시-20시

기댓값: "오후 5시부터 오후 8시까지 <기상예보>"
실제값: "오후 4시부터 오후 8시까지 <기상예보>"

**해결**
원래, 위와 같이 `WeatherRisk`가 현재 시각 이전에 시작하는 경우, 그 시작 시각을 그대로 브리핑 메시지로 전달하였습니다.
예보 그래프는 현재 시각 이후(현재 시(hour)는 포함)로 시작 시각을 수정해 전달하는데, 브리핑 메시지의 시작 시각과 불일치하는 문제가 있었습니다. 일관성을 위해 그래프와 같은 시작 시각 기준을 적용하였습니다.

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)