### PR TITLE
[Feat] 작업 일정 컨테이너 height 동적 증가 및 정각에 refetch 기능 구현

### DIFF
--- a/frontend/src/components/dnd/utils/isFullyOverlapped.ts
+++ b/frontend/src/components/dnd/utils/isFullyOverlapped.ts
@@ -1,10 +1,11 @@
-import { WORK_TIME_Y_COORDINATE_LIST } from '@/constants/workTimeCoordinate';
+import { getYCoordinate } from '@/constants/workTimeCoordinate';
 import { hasCollision } from '@/components/dnd/utils/collisionUtils';
 import type { WorkBlockType } from '@/types/workCard.type';
 
 const isFullyOverlapped = (
   currentDraggingBlock: WorkBlockType,
-  otherBlocks: WorkBlockType[]
+  otherBlocks: WorkBlockType[],
+  maxLayer: number
 ) => {
   const collidesAtY = (y: number) =>
     otherBlocks.some(otherBlock =>
@@ -17,7 +18,12 @@ const isFullyOverlapped = (
       )
     );
 
-  return WORK_TIME_Y_COORDINATE_LIST.every(y => collidesAtY(y));
+  // 동적으로 y좌표 생성 (1부터 maxLayer까지)
+  const dynamicYCoordinates = Array.from({ length: maxLayer }, (_, index) =>
+    getYCoordinate(index + 1)
+  );
+
+  return dynamicYCoordinates.every(y => collidesAtY(y));
 };
 
 export default isFullyOverlapped;

--- a/frontend/src/components/dnd/utils/resolveCollision.ts
+++ b/frontend/src/components/dnd/utils/resolveCollision.ts
@@ -32,7 +32,6 @@ export const resolveCollision = ({
 
   const newBlocks = getTimeUpdatedBlocks(workBlocks, activeBlock);
 
-  // Zustand store에서 최대 레이어 가져오기
   const { maxLayer } = useMaxLayerStore.getState();
 
   if (isFullyOverlapped(activeBlock, otherBlocks, maxLayer)) {

--- a/frontend/src/components/dnd/utils/resolveCollision.ts
+++ b/frontend/src/components/dnd/utils/resolveCollision.ts
@@ -7,6 +7,10 @@ import {
   getTimeUpdatedBlocks,
 } from '@/pages/homePage/utils/work/updateBlockTime';
 import { sortWorkBlocks } from '@/pages/homePage/utils/work/sortWorkBlocks';
+import {
+  WORK_BLOCK_Y_COORDINATE_GAP,
+  getGlobalMaxLayer,
+} from '@/constants/workTimeCoordinate';
 
 interface ResolveCollisionParams {
   activeBlock: WorkBlockType;
@@ -33,17 +37,26 @@ export const resolveCollision = ({
 
   const newBlocks = getTimeUpdatedBlocks(workBlocks, activeBlock);
 
-  if (isFullyOverlapped(activeBlock, otherBlocks)) {
-    const collisionFreePosition = findCollisionFreePosition(
-      activeBlock,
-      otherBlocks,
-      containerRef.current?.getBoundingClientRect() ?? new DOMRect(),
-      scrollOffset
-    );
+  // 전역 변수에서 최대 레이어 가져오기
+  const maxLayer = getGlobalMaxLayer();
+
+  if (isFullyOverlapped(activeBlock, otherBlocks, maxLayer)) {
+    // const collisionFreePosition = findCollisionFreePosition(
+    //   activeBlock,
+    //   otherBlocks,
+    //   containerRef.current?.getBoundingClientRect() ?? new DOMRect(),
+    //   scrollOffset
+    // );
+
+    // 현재 블록이 가득차있는 블록이면 y좌표를 증가하여 생성
+    const newPosition = {
+      x: activeBlock.position.x,
+      y: activeBlock.position.y + WORK_BLOCK_Y_COORDINATE_GAP * (maxLayer - 1),
+    };
 
     const updatedBlock = getTimeUpdatedBlock(activeBlock, {
       ...activeBlock,
-      position: collisionFreePosition,
+      position: newPosition,
     });
 
     const sortedBlocks = sortWorkBlocks(
@@ -53,6 +66,6 @@ export const resolveCollision = ({
     return { updatedBlock, sortedBlocks, newBlocks };
   }
 
-  const sortedBlocks = sortWorkBlocks(newBlocks);
+  const { blocks: sortedBlocks } = sortWorkBlocks(newBlocks);
   return { updatedBlock: activeBlock, sortedBlocks, newBlocks };
 };

--- a/frontend/src/components/dnd/utils/resolveCollision.ts
+++ b/frontend/src/components/dnd/utils/resolveCollision.ts
@@ -1,16 +1,13 @@
 import type { WorkBlockType } from '@/types/workCard.type';
 import type { RefObject } from 'react';
-import { findCollisionFreePosition } from '@/components/dnd/utils/collisionUtils';
 import isFullyOverlapped from '@/components/dnd/utils/isFullyOverlapped';
 import {
   getTimeUpdatedBlock,
   getTimeUpdatedBlocks,
 } from '@/pages/homePage/utils/work/updateBlockTime';
 import { sortWorkBlocks } from '@/pages/homePage/utils/work/sortWorkBlocks';
-import {
-  WORK_BLOCK_Y_COORDINATE_GAP,
-  getGlobalMaxLayer,
-} from '@/constants/workTimeCoordinate';
+import { getYCoordinate } from '@/constants/workTimeCoordinate';
+import useMaxLayerStore from '@/store/useMaxLayerStore';
 
 interface ResolveCollisionParams {
   activeBlock: WorkBlockType;
@@ -28,8 +25,6 @@ interface ResolveCollisionResult {
 export const resolveCollision = ({
   activeBlock,
   workBlocks,
-  containerRef,
-  scrollOffset,
 }: ResolveCollisionParams): ResolveCollisionResult => {
   // 해당 x좌표와 valid한 y좌표 조합에 블록이 이미 존재하는지 확인
   // 블록이 이미 있다면 가능한 위치로 이동
@@ -37,21 +32,14 @@ export const resolveCollision = ({
 
   const newBlocks = getTimeUpdatedBlocks(workBlocks, activeBlock);
 
-  // 전역 변수에서 최대 레이어 가져오기
-  const maxLayer = getGlobalMaxLayer();
+  // Zustand store에서 최대 레이어 가져오기
+  const { maxLayer } = useMaxLayerStore.getState();
 
   if (isFullyOverlapped(activeBlock, otherBlocks, maxLayer)) {
-    // const collisionFreePosition = findCollisionFreePosition(
-    //   activeBlock,
-    //   otherBlocks,
-    //   containerRef.current?.getBoundingClientRect() ?? new DOMRect(),
-    //   scrollOffset
-    // );
-
     // 현재 블록이 가득차있는 블록이면 y좌표를 증가하여 생성
     const newPosition = {
       x: activeBlock.position.x,
-      y: activeBlock.position.y + WORK_BLOCK_Y_COORDINATE_GAP * (maxLayer - 1),
+      y: getYCoordinate(maxLayer),
     };
 
     const updatedBlock = getTimeUpdatedBlock(activeBlock, {
@@ -66,6 +54,6 @@ export const resolveCollision = ({
     return { updatedBlock, sortedBlocks, newBlocks };
   }
 
-  const { blocks: sortedBlocks } = sortWorkBlocks(newBlocks);
+  const sortedBlocks = sortWorkBlocks(newBlocks);
   return { updatedBlock: activeBlock, sortedBlocks, newBlocks };
 };

--- a/frontend/src/constants/workTimeCoordinate.ts
+++ b/frontend/src/constants/workTimeCoordinate.ts
@@ -1,17 +1,8 @@
-export const WORK_TIME_Y_COORDINATE = {
-  1: 395,
-  2: 450,
-  3: 505,
-};
+export const WORK_BLOCK_Y_COORDINATE_GAP = 55;
+export const BASE_TIME_Y_COORDINATE = 395;
+export const WORK_BLOCK_HEIGHT = 52;
 
-export const WORK_TIME_Y_COORDINATE_LIST = [
-  WORK_TIME_Y_COORDINATE[1],
-  WORK_TIME_Y_COORDINATE[2],
-  WORK_TIME_Y_COORDINATE[3],
-];
-
-// y좌표 가져오기
 export const getYCoordinate = (layer: number) =>
-  WORK_TIME_Y_COORDINATE[layer as 1 | 2 | 3] ?? WORK_TIME_Y_COORDINATE[1];
+  BASE_TIME_Y_COORDINATE + (layer - 1) * WORK_BLOCK_Y_COORDINATE_GAP;
 
 export const X_PX_PER_HOUR = 100;

--- a/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
+++ b/frontend/src/pages/homePage/components/workCell/WorkCell.style.ts
@@ -1,9 +1,7 @@
 import { css } from '@emotion/react';
 import { Opacity } from '@/styles/colors';
 import { BorderRadius } from '@/styles/borderRadius';
-import { Typography } from '@/styles/typography';
 import type { WorkCellType, WorkCellStatus } from '@/types/workCell.type';
-import type { Theme } from '@emotion/react';
 
 const borderRadius = {
   Start: css`
@@ -31,23 +29,13 @@ const WorkCellStatusStyle = {
 
 const baseStyle = css`
   width: 96px;
-  height: 176px;
+  min-height: 176px;
+  align-self: stretch;
   transition: background-color 0.1s ease-in-out;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const HoverCell = (theme: Theme) => css`
-  ${Typography.Caption_S}
-  color: ${theme.ColorPrimary.B300};
-  text-align: center;
-  white-space: pre-line;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
 `;
 
 const DragIcon = css`
@@ -67,6 +55,5 @@ const workCell = (type: WorkCellType, status: WorkCellStatus) => css`
 
 export default {
   workCell,
-  HoverCell,
   DragIcon,
 };

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
@@ -10,6 +10,7 @@ const WorkCellsContainerWrapper = (height: number) => css`
   height: ${height + 15}px;
   padding: 16px 12px 16px ${WORK_TIME_DEFAULT_X_COORDINATE}px;
   position: relative;
+  transition: height 0.1s ease-in-out;
 `;
 
 export default { WorkCellsContainerWrapper };

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.style.ts
@@ -1,12 +1,13 @@
 import { css } from '@emotion/react';
 import { WORK_TIME_DEFAULT_X_COORDINATE } from '@/constants/workTimePx';
 
-const WorkCellsContainerWrapper = css`
+const WorkCellsContainerWrapper = (height: number) => css`
   display: flex;
   flex-direction: row;
   gap: 4px;
-  align-items: center;
+  align-items: stretch;
   min-width: max-content;
+  height: ${height + 15}px;
   padding: 16px 12px 16px ${WORK_TIME_DEFAULT_X_COORDINATE}px;
   position: relative;
 `;

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
@@ -2,18 +2,37 @@ import WorkCell from '../workCell/WorkCell';
 import { WORK_CELL_TYPES, WORK_CELL_STATUSES } from '@/types/workCell.type';
 import WorkActiveToolTip from '../workActiveToolTip/WorkActiveToolTip';
 import S from './WorkCellsContainer.style';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import type { RecommendedWorksResponse } from '@/types/openapiGenerator';
+import type { WorkBlockType } from '@/types/workCard.type';
+import {
+  BASE_TIME_Y_COORDINATE,
+  WORK_BLOCK_HEIGHT,
+  getGlobalMaxLayer,
+} from '@/constants/workTimeCoordinate';
 
 const WorkCellsContainer = memo(
   ({
     selectedRecommendedWork,
+    workBlocks,
   }: {
     selectedRecommendedWork: RecommendedWorksResponse | null;
+    workBlocks: WorkBlockType[];
   }) => {
+    // 전역 변수에서 최대 레이어를 가져와서 동적 높이 설정
+    const dynamicHeight = useMemo(() => {
+      if (workBlocks.length === 0) return 176; // 기본 높이
+
+      const maxLayer = getGlobalMaxLayer();
+      const maxY = BASE_TIME_Y_COORDINATE + (maxLayer - 1) * WORK_BLOCK_HEIGHT;
+
+      // 최소 높이 176px 보장
+      return Math.max(maxY, 176);
+    }, [workBlocks]);
+
     return (
       <>
-        <div css={S.WorkCellsContainerWrapper}>
+        <div css={S.WorkCellsContainerWrapper(dynamicHeight)}>
           <WorkActiveToolTip
             selectedRecommendedWork={selectedRecommendedWork}
           />

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
@@ -19,7 +19,6 @@ const WorkCellsContainer = memo(
     selectedRecommendedWork: RecommendedWorksResponse | null;
     workBlocks: WorkBlockType[];
   }) => {
-    // Zustand store에서 최대 레이어 가져오기
     const { maxLayer } = useMaxLayerStore();
 
     // 동적 높이 설정

--- a/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
+++ b/frontend/src/pages/homePage/components/workCellsContainer/WorkCellsContainer.tsx
@@ -7,9 +7,9 @@ import type { RecommendedWorksResponse } from '@/types/openapiGenerator';
 import type { WorkBlockType } from '@/types/workCard.type';
 import {
   BASE_TIME_Y_COORDINATE,
-  WORK_BLOCK_HEIGHT,
-  getGlobalMaxLayer,
+  getYCoordinate,
 } from '@/constants/workTimeCoordinate';
+import useMaxLayerStore from '@/store/useMaxLayerStore';
 
 const WorkCellsContainer = memo(
   ({
@@ -19,20 +19,22 @@ const WorkCellsContainer = memo(
     selectedRecommendedWork: RecommendedWorksResponse | null;
     workBlocks: WorkBlockType[];
   }) => {
-    // 전역 변수에서 최대 레이어를 가져와서 동적 높이 설정
-    const dynamicHeight = useMemo(() => {
+    // Zustand store에서 최대 레이어 가져오기
+    const { maxLayer } = useMaxLayerStore();
+
+    // 동적 높이 설정
+    const workCellsContainerHeight = useMemo(() => {
       if (workBlocks.length === 0) return 176; // 기본 높이
 
-      const maxLayer = getGlobalMaxLayer();
-      const maxY = BASE_TIME_Y_COORDINATE + (maxLayer - 1) * WORK_BLOCK_HEIGHT;
+      const maxY = getYCoordinate(maxLayer + 1) - BASE_TIME_Y_COORDINATE;
 
       // 최소 높이 176px 보장
       return Math.max(maxY, 176);
-    }, [workBlocks]);
+    }, [workBlocks, maxLayer]);
 
     return (
       <>
-        <div css={S.WorkCellsContainerWrapper(dynamicHeight)}>
+        <div css={S.WorkCellsContainerWrapper(workCellsContainerHeight)}>
           <WorkActiveToolTip
             selectedRecommendedWork={selectedRecommendedWork}
           />

--- a/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
+++ b/frontend/src/pages/homePage/components/workContainer/WorkContainer.tsx
@@ -182,6 +182,7 @@ const WorkContainer = ({
             })}
             <WorkCellsContainer
               selectedRecommendedWork={selectedRecommendedWork}
+              workBlocks={workBlocks}
             />
           </div>
         </div>

--- a/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
+++ b/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
@@ -68,15 +68,6 @@ export const useCreateWorkBlock = ({
           endTime: tempEndTime,
         };
 
-        // 충돌하지 않는 위치 찾기
-        // const collisionFreePosition = findCollisionFreePosition(
-        //   tempBlock,
-        //   workBlocks,
-        //   containerRect,
-        //   scrollOffset
-        // );
-        //현재 x좌표와 현존하는 가능한 y좌표들이 모두 가득차있으면 y좌표를 증가하여 생성
-
         // updateWorkTime 함수를 사용하여 최종 시간 계산
         const {
           newStartTime: finalStartTime,

--- a/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
+++ b/frontend/src/pages/homePage/hooks/work/useCreateWorkBlock.ts
@@ -6,7 +6,6 @@ import type {
   RecommendedWorksResponse,
 } from '@/types/openapiGenerator';
 import { getYCoordinate, X_PX_PER_HOUR } from '@/constants/workTimeCoordinate';
-import { findCollisionFreePosition } from '@/components/dnd/utils/collisionUtils';
 import updateWorkTime from '@/pages/homePage/utils/work/updateWorkTime';
 import { snapToGrid } from '@/utils/snapToGrid';
 
@@ -31,9 +30,7 @@ interface UseCreateWorkBlockProps {
 
 export const useCreateWorkBlock = ({
   containerRef,
-  scrollOffset,
   addWorkBlock,
-  workBlocks,
 }: UseCreateWorkBlockProps): UseCreateWorkBlockReturn => {
   const handleCreateWork = useCallback(
     async (
@@ -72,23 +69,20 @@ export const useCreateWorkBlock = ({
         };
 
         // 충돌하지 않는 위치 찾기
-        const collisionFreePosition = findCollisionFreePosition(
-          tempBlock,
-          workBlocks,
-          containerRect,
-          scrollOffset
-        );
+        // const collisionFreePosition = findCollisionFreePosition(
+        //   tempBlock,
+        //   workBlocks,
+        //   containerRect,
+        //   scrollOffset
+        // );
+        //현재 x좌표와 현존하는 가능한 y좌표들이 모두 가득차있으면 y좌표를 증가하여 생성
 
         // updateWorkTime 함수를 사용하여 최종 시간 계산
         const {
           newStartTime: finalStartTime,
           newEndTime: finalEndTime,
           newWorkTime,
-        } = updateWorkTime(
-          tempBlock.startTime,
-          tempBlock.endTime,
-          collisionFreePosition
-        );
+        } = updateWorkTime(tempBlock.startTime, tempBlock.endTime, position);
 
         // 최종 작업 블록 생성 및 시간 업데이트
         const newWorkBlock: WorkBlockType = {
@@ -96,7 +90,7 @@ export const useCreateWorkBlock = ({
           startTime: finalStartTime,
           endTime: finalEndTime,
           workTime: newWorkTime,
-          position: collisionFreePosition,
+          position,
         };
 
         addWorkBlock(newWorkBlock, selectedCrop.myCropId!, work.workId!);
@@ -104,7 +98,7 @@ export const useCreateWorkBlock = ({
         console.error('작업 블록 생성 실패:', error);
       }
     },
-    [addWorkBlock, workBlocks, containerRef, scrollOffset]
+    [addWorkBlock, containerRef]
   );
 
   return {

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -13,12 +13,7 @@ const useWorkBlocks = () => {
 
   const { animateBlocksTransition } = useBlocksTransition(setWorkBlocks);
 
-  const {
-    data: initialWorkBlocks,
-    isLoading,
-    error,
-    refetch,
-  } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ['myWorkOfToday'],
     queryFn: async () => {
       const res = await getMyWorkOfToday(false);
@@ -30,12 +25,12 @@ const useWorkBlocks = () => {
   const prevWorkBlocksRef = useRef<WorkBlockType[]>([]);
 
   useEffect(() => {
-    if (initialWorkBlocks) {
-      const sortedBlocks = sortWorkBlocks(initialWorkBlocks);
+    if (data) {
+      const sortedBlocks = sortWorkBlocks(data);
       animateBlocksTransition(prevWorkBlocksRef.current, sortedBlocks);
       prevWorkBlocksRef.current = sortedBlocks;
     }
-  }, [initialWorkBlocks, animateBlocksTransition]);
+  }, [data, animateBlocksTransition]);
 
   useEffect(() => {
     if (currentTime.minute() === 0) {
@@ -87,8 +82,6 @@ const useWorkBlocks = () => {
 
   return {
     workBlocks,
-    isLoading,
-    error,
     addWorkBlock,
     updateWorkBlocks,
     removeWorkBlock,

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -1,26 +1,47 @@
-import { useEffect, useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import type { WorkBlockType } from '@/types/workCard.type';
 import { getMyWorkOfToday, deleteMyWork, postMyWork } from '@/apis/myWork.api';
 import getInitialWorkBlocks from '@/pages/homePage/utils/work/getInitialWorkBlocks';
 import useBlocksTransition from '@/components/dnd/hooks/useBlocksTransition';
 import { sortWorkBlocks } from '../../utils/work/sortWorkBlocks';
+import { useTimeStore } from '@/store/useTimeStore';
 
 const useWorkBlocks = () => {
+  const { currentTime } = useTimeStore();
   const [workBlocks, setWorkBlocks] = useState<WorkBlockType[]>([]);
 
   const { animateBlocksTransition } = useBlocksTransition(setWorkBlocks);
 
-  useEffect(() => {
-    const fetchMyWorkOfToday = async () => {
+  const {
+    data: initialWorkBlocks,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['myWorkOfToday'],
+    queryFn: async () => {
       const res = await getMyWorkOfToday(false);
-      setWorkBlocks(getInitialWorkBlocks(res.data));
-    };
-    try {
-      fetchMyWorkOfToday();
-    } catch (error) {
-      console.error('오늘 내 농작업 일정 조회 실패', error);
+      return getInitialWorkBlocks(res.data);
+    },
+    staleTime: 55 * 60 * 1000,
+  });
+
+  const prevWorkBlocksRef = useRef<WorkBlockType[]>([]);
+
+  useEffect(() => {
+    if (initialWorkBlocks) {
+      const sortedBlocks = sortWorkBlocks(initialWorkBlocks);
+      animateBlocksTransition(prevWorkBlocksRef.current, sortedBlocks);
+      prevWorkBlocksRef.current = sortedBlocks;
     }
-  }, []);
+  }, [initialWorkBlocks, animateBlocksTransition]);
+
+  useEffect(() => {
+    if (currentTime.minute() === 0) {
+      refetch();
+    }
+  }, [currentTime, refetch]);
 
   const addWorkBlock = async (
     newWorkBlock: WorkBlockType,
@@ -66,6 +87,8 @@ const useWorkBlocks = () => {
 
   return {
     workBlocks,
+    isLoading,
+    error,
     addWorkBlock,
     updateWorkBlocks,
     removeWorkBlock,

--- a/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
@@ -12,7 +12,7 @@ export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
     (a, b) => dayjs(a.startTime).valueOf() - dayjs(b.startTime).valueOf()
   );
 
-  // 2. 레이어별 작업 저장 (동적으로 확장)
+  // 2. 레이어별 작업 저장
   const layers: { [layer: number]: WorkBlockType[] } = {};
   const blocks: WorkBlockType[] = [];
 
@@ -75,7 +75,6 @@ export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
     });
   }
 
-  // Zustand store에 maxLayer 업데이트
   const { updateMaxLayerFromWorkBlocks } = useMaxLayerStore.getState();
   updateMaxLayerFromWorkBlocks(blocks);
 

--- a/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
@@ -75,8 +75,5 @@ export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
     });
   }
 
-  const { updateMaxLayerFromWorkBlocks } = useMaxLayerStore.getState();
-  updateMaxLayerFromWorkBlocks(blocks);
-
   return blocks;
 };

--- a/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
@@ -16,8 +16,7 @@ export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
   const layers: { [layer: number]: WorkBlockType[] } = {};
   const blocks: WorkBlockType[] = [];
 
-  // 현재 maxLayer 가져오기
-  let currentMaxLayer = useMaxLayerStore.getState().maxLayer;
+  let currentMaxLayer = 1;
 
   for (const work of sortedWorks) {
     const { x, width } = calculateTimeToPosition(
@@ -74,6 +73,8 @@ export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
       size: { width, height: 52 },
     });
   }
+
+  useMaxLayerStore.setState({ maxLayer: currentMaxLayer });
 
   return blocks;
 };

--- a/frontend/src/store/useMaxLayerStore.ts
+++ b/frontend/src/store/useMaxLayerStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import {
+  BASE_TIME_Y_COORDINATE,
+  WORK_BLOCK_Y_COORDINATE_GAP,
+} from '@/constants/workTimeCoordinate';
+
+interface MaxLayerState {
+  maxLayer: number;
+  setMaxLayer: (maxLayer: number) => void;
+  updateMaxLayerFromWorkBlocks: (
+    workBlocks: { position: { y: number } }[]
+  ) => void;
+  incrementMaxLayer: () => void;
+}
+
+const useMaxLayerStore = create<MaxLayerState>(set => ({
+  maxLayer: 1,
+  setMaxLayer: (maxLayer: number) => set({ maxLayer }),
+  updateMaxLayerFromWorkBlocks: (workBlocks: { position: { y: number } }[]) => {
+    if (workBlocks.length === 0) {
+      set({ maxLayer: 1 });
+      return;
+    }
+
+    const maxY = Math.max(...workBlocks.map(block => block.position.y));
+    const newMaxLayer =
+      Math.ceil((maxY - BASE_TIME_Y_COORDINATE) / WORK_BLOCK_Y_COORDINATE_GAP) +
+      1;
+
+    set({ maxLayer: newMaxLayer });
+  },
+  incrementMaxLayer: () => set(state => ({ maxLayer: state.maxLayer + 1 })),
+}));
+
+export default useMaxLayerStore;

--- a/frontend/src/store/useMaxLayerStore.ts
+++ b/frontend/src/store/useMaxLayerStore.ts
@@ -1,33 +1,13 @@
 import { create } from 'zustand';
-import {
-  BASE_TIME_Y_COORDINATE,
-  WORK_BLOCK_Y_COORDINATE_GAP,
-} from '@/constants/workTimeCoordinate';
 
 interface MaxLayerState {
   maxLayer: number;
   setMaxLayer: (maxLayer: number) => void;
-  updateMaxLayerFromWorkBlocks: (
-    workBlocks: { position: { y: number } }[]
-  ) => void;
 }
 
 const useMaxLayerStore = create<MaxLayerState>(set => ({
   maxLayer: 1,
   setMaxLayer: (maxLayer: number) => set({ maxLayer }),
-  updateMaxLayerFromWorkBlocks: (workBlocks: { position: { y: number } }[]) => {
-    if (workBlocks.length === 0) {
-      set({ maxLayer: 1 });
-      return;
-    }
-
-    const maxY = Math.max(...workBlocks.map(block => block.position.y));
-    const newMaxLayer =
-      Math.ceil((maxY - BASE_TIME_Y_COORDINATE) / WORK_BLOCK_Y_COORDINATE_GAP) +
-      1;
-
-    set({ maxLayer: newMaxLayer });
-  },
 }));
 
 export default useMaxLayerStore;

--- a/frontend/src/store/useMaxLayerStore.ts
+++ b/frontend/src/store/useMaxLayerStore.ts
@@ -10,7 +10,6 @@ interface MaxLayerState {
   updateMaxLayerFromWorkBlocks: (
     workBlocks: { position: { y: number } }[]
   ) => void;
-  incrementMaxLayer: () => void;
 }
 
 const useMaxLayerStore = create<MaxLayerState>(set => ({
@@ -29,7 +28,6 @@ const useMaxLayerStore = create<MaxLayerState>(set => ({
 
     set({ maxLayer: newMaxLayer });
   },
-  incrementMaxLayer: () => set(state => ({ maxLayer: state.maxLayer + 1 })),
 }));
 
 export default useMaxLayerStore;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #533

---

## 📝작업 내용

- 정각에 refetch
- 작업 일정 추가 시 놓을 수 있는 위치가 없을 경우 가능한 다른 위치에 등록을 시켜버리는 플로우가 정말 맞는 건지에 대한 고민을 많이 해봤는데요...
현재 기획상 같은 시간대에 작업은 3줄까지만 등록이 가능하고, 그 이후는 같은 시간대에 등록이 불가합니다.

그리고 dnd를 쓰는 다른 서비스도 많이 찾아봤는데.. 일정 등록을 하는 서비스의 경우 무한히 늘어나더라도 사용자의 등록에 한계를 두는 경우는 별로 없더라구요
drag and drop ui라는건 사용자에게 주는 자유도가 무척 중요한 ui라는 생각을 했어요.
dnd에서 가장 중요한건 사용자가 인터페이스를 원하는대로 제어하는 것이라, 정확히 원하는 시간에 일정을 등록할 수 있도록 자유도를 보장하는 게 더 중요하다는 생각을 했습니다..


서비스에서 동시대에 작업하는 걸 꼭 막아야하는 이유도 없는 것 같아서 제한을 풀고 같은 시간대에 무제한으로 등록할 수 있게 변경했습니다... 


---

### 스크린샷 (선택)

https://github.com/user-attachments/assets/2e47ab83-846f-4731-b6c1-69deac364f6d


정각에 refetch는 되는데 00시에 시작했던 작업이 데이터 refetch 시 갑자기 사라지는건 확인해보니 api 문제 같아서...... 세연님꼐 여쭤보겠습니다

https://github.com/user-attachments/assets/9ac55858-d3fb-4622-8d2f-868e8fbf19a8


---

## 💬리뷰 요구사항

maxYlayer은 작업일정 컨테이너에만 쓰이는 부분이라 전역변수로 사용하기 적절치 않다고 생각해 context api로 구현할까 고민했는데, zustand를 사용하는게 빠르고 가독성도 좋아서 zustand를 사용했습니다.

context api와 zustand 사이 고민되는데 뭐가 더 나을지, 어떤 방법이 더 적절할지 리뷰 부탁드려요..

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)