### PR TITLE
[Hotfix] 기상 그래프 조회 API에서 24시간 이후 데이터까지만 조회안되는 오류 해결

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -42,6 +42,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -85,17 +86,14 @@ public class WeatherService {
         int ny = farm.getNy();
 
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime start = now.truncatedTo(ChronoUnit.HOURS);
+        LocalDateTime end = start.plusHours(23);
+
         List<ShortTermWeatherForecast> weatherInfos = shortTermWeatherForecastRepository.findAllByNxAndNy(nx, ny)
                 .stream()
                 .filter(weather -> {
                     LocalDateTime fcstTime = weather.getFcstTime();
-                    LocalDate fcstDate = fcstTime.toLocalDate();
-                    LocalDate nowDate = now.toLocalDate();
-
-                    if(fcstDate.isEqual(nowDate)){
-                        return fcstTime.getHour() >= now.getHour();
-                    }
-                    return fcstTime.getHour() < now.getHour();
+                    return !fcstTime.isBefore(start) && !fcstTime.isAfter(end);
                 })
                 .toList();
         if (weatherInfos.isEmpty()) {


### PR DESCRIPTION
## 📌 연관된 이슈

- close #537 

---

## 📝작업 내용

단기예보 batch에서 48시간 이후 데이터까지 받도록 수정하자, 홈페이지 기상 그래프 조회 API 로직에 문제가 생겼습니다. 
24시간 이후 데이터를 가져오는 방식에 문제가 생겨서 날짜 기반으로 24시간을 계산하도록 로직을 수정했습니다. 

<img width="1391" height="605" alt="image" src="https://github.com/user-attachments/assets/a7041bd6-d1b8-49a1-9880-a10e8bba89c1" />


---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)