### PR TITLE
[Feat] `MyWorkCompleted` 이벤트 핸들링 비동기 실행 

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/NyeoreumnagiApplication.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/NyeoreumnagiApplication.java
@@ -2,9 +2,10 @@ package com.imsnacks.Nyeoreumnagi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class NyeoreumnagiApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/controller/MyWorkController.java
@@ -19,11 +19,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEventListener.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/work/event/MyWorkCompletedEventListener.java
@@ -3,17 +3,24 @@ package com.imsnacks.Nyeoreumnagi.work.event;
 import ch.hsr.geohash.GeoHash;
 import com.imsnacks.Nyeoreumnagi.work.repository.WorkActivityFactRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MyWorkCompletedEventListener {
     private final WorkActivityFactRepository workActivityFactRepository;
 
-    @EventListener
+    @Async
+    @TransactionalEventListener(
+            classes = MyWorkCompletedEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT
+    )
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handle(MyWorkCompletedEvent event) {
         String geohash = GeoHash.withCharacterPrecision(
                 event.latitude(),


### PR DESCRIPTION
## 📌 연관된 이슈

- close #543

---

## 📝작업 내용

1.  `MyWorkCompleted` 이벤트 핸들링을 비동기로 처리할 수 있도록 개선했습니다.
- 상태를 변경하는 것과 이벤트 핸들링은 관심사가 분리되어야 한다고 생각해서 비동기로 처리했습니다.
- 응답 속도 상 큰 차이는 없습니다.

2. `@EventListener` 대신 `@TransactionalEventListener`을 사용해서 phase 를 `TransactionPhase.AFTER_COMMIT`로 설정했습니다. 트랜잭션이 성공할 때만 후에 이벤트가 실행됩니다.
- `@Transactional(propagation = Propagation.REQUIRES_NEW)` 로 설정했습니다.
-  트랜잭션의 기본 propagation 설정값은 REQUIRED인데 이 설정은 기존 트랜잭션이 있으면 참석하고 없으면 새롭게 생성합니다. phase를 위와 같이 커밋 이후로 설정했으므로 새로운 트랜잭션을 생성해야 합니다. 
---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)