### PR TITLE
[Fix] 리액트 쿼리 적용 후 post/delete/patch 시 데이터 업데이트 안됨 문제 해결

### DIFF
--- a/frontend/src/components/dnd/draggableItem/DraggableItem.tsx
+++ b/frontend/src/components/dnd/draggableItem/DraggableItem.tsx
@@ -20,7 +20,7 @@ const DraggableItem = ({
         top: 0;
         transform: translate3d(${position.x}px, ${position.y}px, 0);
 
-        opacity: ${isDragging ? 0.5 : 1};
+        opacity: ${isDragging ? 0 : 1};
         pointer-events: auto;
         z-index: 1000;
       `}

--- a/frontend/src/components/dnd/hooks/useDragBlock.ts
+++ b/frontend/src/components/dnd/hooks/useDragBlock.ts
@@ -10,6 +10,7 @@ import { useBlocksTransition } from '@/components/dnd/hooks/useBlocksTransition'
 import { resolveCollision } from '../utils/resolveCollision';
 import { snapPositionToGrid } from '@/utils/snapToGrid';
 import { getTimeUpdatedBlocks } from '@/pages/homePage/utils/work/updateBlockTime';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface UseDragBlockProps {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -37,6 +38,8 @@ export const useDragBlock = ({
   // 블록 이동 애니메이션 훅
   const { animateBlocksTransition } =
     useBlocksTransition<WorkBlockType>(updateWorkBlocks);
+
+  const queryClient = useQueryClient();
 
   const getContainerCoords = useCallback(
     (e: PointerEvent) => {
@@ -103,7 +106,6 @@ export const useDragBlock = ({
 
     const currentDraggingBlock = draggingBlock;
 
-    // 상태 초기화
     setDraggingBlock(null);
     setDragPointerPosition(null);
 
@@ -138,11 +140,12 @@ export const useDragBlock = ({
 
     animateBlocksTransition(newBlocks, sortedBlocks);
 
-    await updateBlockTimeOnServer(updatedBlock);
+    await updateBlockTimeOnServer(updatedBlock, queryClient);
   }, [
     animateBlocksTransition,
     containerRef,
     draggingBlock,
+    queryClient,
     scrollOffset,
     workBlocks,
   ]);

--- a/frontend/src/components/dnd/hooks/useResizeBlock.ts
+++ b/frontend/src/components/dnd/hooks/useResizeBlock.ts
@@ -11,6 +11,7 @@ import {
   snapWidthToGrid,
   snapToGrid,
 } from '@/utils/snapToGrid';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface UseResizeBlockProps {
   containerRef: RefObject<HTMLDivElement | null>;
@@ -31,6 +32,8 @@ export const useResizeBlock = ({
   const [resizeDirection, setResizeDirection] = useState<
     'left' | 'right' | null
   >(null);
+
+  const queryClient = useQueryClient();
 
   const { animateBlocksTransition } =
     useBlocksTransition<WorkBlockType>(updateWorkBlocks);
@@ -130,13 +133,14 @@ export const useResizeBlock = ({
 
     animateBlocksTransition(newBlocks, sortedBlocks);
 
-    await updateBlockTimeOnServer(updatedBlock);
+    await updateBlockTimeOnServer(updatedBlock, queryClient);
   }, [
-    animateBlocksTransition,
+    resizingBlock,
+    workBlocks,
     containerRef,
     scrollOffset,
-    workBlocks,
-    resizingBlock,
+    animateBlocksTransition,
+    queryClient,
   ]);
 
   useSetPointerEvents({

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -72,7 +72,7 @@ const useWorkBlocks = () => {
 
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['myWorkOfToday'] });
-      }, 250);
+      }, 1000);
     } catch (error) {
       console.error('작업 추가 실패', error);
     }
@@ -98,7 +98,7 @@ const useWorkBlocks = () => {
       skipAnimationRef.current = true;
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['myWorkOfToday'] });
-      }, 250);
+      }, 1000);
     } catch (error) {
       console.error('작업 삭제 실패', error);
     }

--- a/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
+++ b/frontend/src/pages/homePage/hooks/work/useWorkBlocks.ts
@@ -26,17 +26,16 @@ const useWorkBlocks = () => {
   const skipAnimationRef = useRef(false);
 
   useEffect(() => {
-    if (data) {
-      const sortedBlocks = sortWorkBlocks(data);
-      if (skipAnimationRef.current) {
-        setWorkBlocks(sortedBlocks);
-        prevWorkBlocksRef.current = sortedBlocks;
-        skipAnimationRef.current = false;
-        return;
-      }
-      animateBlocksTransition(prevWorkBlocksRef.current, sortedBlocks);
+    if (!data) return;
+    const sortedBlocks = sortWorkBlocks(data);
+    if (skipAnimationRef.current) {
+      setWorkBlocks(sortedBlocks);
       prevWorkBlocksRef.current = sortedBlocks;
+      skipAnimationRef.current = false;
+      return;
     }
+    animateBlocksTransition(prevWorkBlocksRef.current, sortedBlocks);
+    prevWorkBlocksRef.current = sortedBlocks;
   }, [data, animateBlocksTransition]);
 
   useEffect(() => {

--- a/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
+++ b/frontend/src/pages/homePage/utils/work/sortWorkBlocks.ts
@@ -9,7 +9,8 @@ import useMaxLayerStore from '@/store/useMaxLayerStore';
 export const sortWorkBlocks = (workBlocks: WorkBlockType[]) => {
   // 1. 시작 시간 기준 정렬
   const sortedWorks = [...workBlocks].sort(
-    (a, b) => dayjs(a.startTime).valueOf() - dayjs(b.startTime).valueOf()
+    (a, b) =>
+      dayjs(a.startTime).valueOf() - dayjs(b.startTime).valueOf() || a.id - b.id
   );
 
   // 2. 레이어별 작업 저장

--- a/frontend/src/pages/homePage/utils/work/updateBlockTimeOnServer.ts
+++ b/frontend/src/pages/homePage/utils/work/updateBlockTimeOnServer.ts
@@ -1,7 +1,11 @@
 import { patchMyWorkTime } from '@/apis/myWork.api';
 import type { WorkBlockType } from '@/types/workCard.type';
+import { QueryClient } from '@tanstack/react-query';
 
-const updateBlockTimeOnServer = async (updatedBlock: WorkBlockType) => {
+const updateBlockTimeOnServer = async (
+  updatedBlock: WorkBlockType,
+  queryClient: QueryClient
+) => {
   try {
     await patchMyWorkTime({
       myWorkId: updatedBlock.id,
@@ -11,6 +15,9 @@ const updateBlockTimeOnServer = async (updatedBlock: WorkBlockType) => {
   } catch (error) {
     console.error('작업 시간 업데이트 실패:', error);
   }
+  setTimeout(() => {
+    queryClient.invalidateQueries({ queryKey: ['myWorkOfToday'] });
+  }, 250);
 };
 
 export default updateBlockTimeOnServer;

--- a/frontend/src/pages/homePage/utils/work/updateBlockTimeOnServer.ts
+++ b/frontend/src/pages/homePage/utils/work/updateBlockTimeOnServer.ts
@@ -17,7 +17,7 @@ const updateBlockTimeOnServer = async (
   }
   setTimeout(() => {
     queryClient.invalidateQueries({ queryKey: ['myWorkOfToday'] });
-  }, 250);
+  }, 1000);
 };
 
 export default updateBlockTimeOnServer;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #542
---

## 📝작업 내용

- 리액트 쿼리 적용 후 post/delete/patch 시 데이터가 업데이트 되지 않아, 다른페이지에 방문한 후 돌아오면 이전 데이터가 남아있는 문제가 있었습니다.
- 캐시 무효화를 적용했으며, dnd와 resize에 애니메이팅이 들어가기에 애니메이팅이 끝난 후 캐시 무효화를 하기위해 setTimeout으로 1초 후 캐시 무효화를 진행했습니다.

- 정각에 refetch: 작업 블록이 옆으로 이동하는 애니메이션 필요
- 그 외 추가, 수정, 삭제: setState로 직접 애니메이션 관리
애니메이팅이 되어야하는 조건이 두가지로 나뉘므로 정각에 refetch할 때만 애니메이션이 작동하고, 그 외에는 서버에서 데이터를 새로 호출받아도  불필요한 애니메이션이 실행되지 않도록 skipAnimationRef 값을 이용해 분기 처리를 했습니다.
- 시작 시간이 같은 경우 sort할 때 작업 등록 순서(id)순으로 정렬되게 정렬 조건을 추가했습니다.

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)