### PR TITLE
[Refactor] 기상청 단기예보 batch 실패시 tomorrow.io 호출하도록 수정

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/AlterApiCaller.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/AlterApiCaller.java
@@ -1,0 +1,139 @@
+package com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.processor;
+
+import com.ImSnacks.NyeoreumnagiBatch.shortTermWeatherForecast.reader.dto.VilageFcstResponseDto;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@EnableRetry
+@Component
+public class AlterApiCaller {
+    @Value("${api.tomorrow.key}")
+    private String secretKey;
+
+    private HttpClient httpClient;
+
+    public AlterApiCaller() {
+        httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .build();
+
+    }
+
+    @Retryable(
+            maxAttempts = 3,
+            value = Exception.class,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
+    public VilageFcstResponseDto call(String baseDate, String baseTime, double latitude, double longitude, int nx, int ny) throws IOException, InterruptedException {
+        URI uri = buildUri(baseDate, baseTime, latitude, longitude);
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(uri)
+                .version(HttpClient.Version.HTTP_1_1)
+                .timeout(Duration.of(30, ChronoUnit.SECONDS))
+                .GET().build();
+
+        HttpResponse<String> res = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+
+        ObjectMapper mapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+
+        JsonNode root = mapper.readTree(res.body());
+
+        return convertToVilageFcstResponseDto(baseDate, baseTime, root, nx, ny);
+    }
+
+    private URI buildUri(String baseDate, String baseTime, double latitude, double longitude) {
+        return UriComponentsBuilder.fromUriString("https://api.tomorrow.io/v4/weather/forecast")
+                .queryParam("location", latitude + "," + longitude)
+                .queryParam("apikey", secretKey)
+                .encode()
+                .build()
+                .toUri();
+    }
+
+    private VilageFcstResponseDto convertToVilageFcstResponseDto(String baseDate, String baseTime, JsonNode root, int nx, int ny) {
+        List<VilageFcstResponseDto.Item> items = new ArrayList<>();
+
+        for (JsonNode hourlyNode : root.path("timelines").path("hourly")) {
+            String utcTime = hourlyNode.path("time").asText();
+            ZonedDateTime kst = ZonedDateTime.parse(utcTime)
+                    .withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+
+            String fcstDate = kst.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            String fcstTime = kst.format(DateTimeFormatter.ofPattern("HHmm"));
+
+            JsonNode values = hourlyNode.path("values");
+
+            addItem(items, "PCP", fcstDate, fcstTime, values.path("rainIntensity").asText(), nx, ny, baseDate, baseTime);
+            addItem(items, "TMP", fcstDate, fcstTime, String.valueOf(values.path("temperature").asInt()), nx, ny, baseDate, baseTime);
+            addItem(items, "REH", fcstDate, fcstTime, String.valueOf(values.path("humidity").asInt()), nx, ny, baseDate, baseTime);
+            addItem(items, "WSD", fcstDate, fcstTime, values.path("windSpeed").asText(), nx, ny, baseDate, baseTime);
+            addItem(items, "SNO", fcstDate, fcstTime, values.path("snowIntensity").asText(), nx, ny, baseDate, baseTime);
+
+            double cloudCover = values.path("cloudBase").asDouble();
+            String skyValue = (cloudCover <= 0.3) ? "1" : (cloudCover <= 0.6 ? "3" : "4");
+            addItem(items, "SKY", fcstDate, fcstTime, skyValue, nx, ny, baseDate, baseTime);
+
+            addItem(items, "VEC", fcstDate, fcstTime, values.path("windDirection").asText(), nx, ny, baseDate, baseTime);
+        }
+
+        VilageFcstResponseDto.Items itemsWrapper = new VilageFcstResponseDto.Items();
+        itemsWrapper.setItem(items);
+
+        VilageFcstResponseDto.Body body = new VilageFcstResponseDto.Body();
+        body.setItems(itemsWrapper);
+
+        VilageFcstResponseDto.Header header = new VilageFcstResponseDto.Header();
+        header.setResultCode("00");
+        header.setResultMsg("OK");
+
+        VilageFcstResponseDto.Response response = new VilageFcstResponseDto.Response();
+        response.setHeader(header);
+        response.setBody(body);
+
+        VilageFcstResponseDto dto = new VilageFcstResponseDto();
+        dto.setResponse(response);
+
+        return dto;
+    }
+
+    private void addItem(List<VilageFcstResponseDto.Item> items, String category,
+                         String fcstDate, String fcstTime, String value,
+                         int nx, int ny,
+                         String baseDate, String baseTime) {
+        VilageFcstResponseDto.Item item = new VilageFcstResponseDto.Item();
+        item.setCategory(category);
+        item.setFcstDate(fcstDate);
+        item.setFcstTime(fcstTime);
+        item.setFcstValue(value);
+        item.setNx(nx);
+        item.setNy(ny);
+        item.setBaseDate(baseDate);
+        item.setBaseTime(baseTime);
+        items.add(item);
+    }
+}

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/ImprovedApiCaller.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/ImprovedApiCaller.java
@@ -37,11 +37,11 @@ public class ImprovedApiCaller {
 
     }
 
-//    @Retryable(
-//            maxAttempts = 3,
-//            value = IOException.class,
-//            backoff = @Backoff(delay = 2000, multiplier = 2)
-//    )
+    @Retryable(
+            maxAttempts = 3,
+            value = IOException.class,
+            backoff = @Backoff(delay = 2000, multiplier = 2)
+    )
     public VilageFcstResponseDto call(String baseDate, String baseTime, int nx, int ny) {
         URI uri = buildUri(baseDate, baseTime, nx, ny);
         log.info("Calling web service at {}", uri.toString());
@@ -58,14 +58,13 @@ public class ImprovedApiCaller {
                     .readValue(res.body(), VilageFcstResponseDto.class);
             return data;
         } catch (Exception e) {
-            // TODO 모든 예외에 기본 데이터 반환으로 대응하는 상태.
-            // TODO 재시도 기능 도입하기.
-            // TODO 실패하면 큐에 담아두고 다시 시도하기.
             log.info("An exception has occurred");
-            return getDefaultData(baseDate, baseTime, nx, ny);
+            return null;
         }
 
     }
+
+
 
     private java.net.URI buildUri(String baseDate, String baseTime, int nx, int ny) {
         return UriComponentsBuilder.fromUriString(ApiRequestValues.URI.toString())

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/ImprovedWeatherProcessor.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/processor/ImprovedWeatherProcessor.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Slf4j
 @StepScope
 @Component
@@ -20,18 +22,18 @@ public class ImprovedWeatherProcessor implements ItemProcessor<UniqueNxNy, Short
     @Autowired
     private final WeatherProcessor processor;
     @Autowired
-    private final ApiCaller apiCaller;
-    @Autowired
     private final ImprovedApiCaller improvedApiCaller;
+    @Autowired
+    private final AlterApiCaller alterApiCaller;
     @Value("#{jobParameters['base_date']}")
     private String baseDate;
     @Value("#{jobParameters['base_time']}")
     private String baseTime;
 
-    public ImprovedWeatherProcessor(WeatherProcessor processor, ApiCaller apiCaller, ImprovedApiCaller improvedApiCaller) {
+    public ImprovedWeatherProcessor(WeatherProcessor processor, ImprovedApiCaller improvedApiCaller, AlterApiCaller alterApiCaller) {
         this.processor = processor;
-        this.apiCaller = apiCaller;
         this.improvedApiCaller = improvedApiCaller;
+        this.alterApiCaller = alterApiCaller;
     }
 
     @Override
@@ -39,15 +41,53 @@ public class ImprovedWeatherProcessor implements ItemProcessor<UniqueNxNy, Short
         int nx = loc.getId().getNx();
         int ny = loc.getId().getNy();
 
-        log.info("Processing nx={}, ny={} with Thread: {}", nx, ny, Thread.currentThread().getName());
-
         VilageFcstResponseDto response = improvedApiCaller.call(baseDate, baseTime, nx, ny);
         if (response == null || response.getWeatherInfo() == null || response.getWeatherInfo().isEmpty()) {
-            log.warn("API response is empty for nx={}, ny={}", loc.getId().getNx(), loc.getId().getNy());
-            return null; // Writer로 전달하지 않고 건너뜀
+            log.warn("Primary API response is empty for nx={}, ny={}", loc.getId().getNx(), loc.getId().getNy());
+            response = alterApiCaller.call(baseDate, baseTime, loc.getLatitude(), loc.getLongitude(), nx, ny);
+            if(response == null || response.getWeatherInfo() == null || response.getWeatherInfo().isEmpty()) {
+                log.warn("Secondary API response is empty for nx={}, ny={}", nx, ny);
+                response = getDefaultData(baseDate, baseTime);
+            }
         }
-
         return processor.process(response);
+    }
+
+    private VilageFcstResponseDto getDefaultData(String baseDate, String baseTime) {
+        List<VilageFcstResponseDto.Item> itemList = List.of(
+                createItem("PCP", baseDate, baseTime, baseDate, baseTime, "강수없음")
+        );
+        VilageFcstResponseDto.Items items = new VilageFcstResponseDto.Items();
+        items.setItem(itemList);
+
+        VilageFcstResponseDto.Body body = new VilageFcstResponseDto.Body();
+        body.setItems(items);
+
+        VilageFcstResponseDto.Header header = new VilageFcstResponseDto.Header();
+        header.setResultCode("00");
+        header.setResultMsg("OK");
+
+        VilageFcstResponseDto.Response response = new VilageFcstResponseDto.Response();
+        response.setHeader(header);
+        response.setBody(body);
+
+        VilageFcstResponseDto VilageFcstResponseDto = new VilageFcstResponseDto();
+        VilageFcstResponseDto.setResponse(response);
+
+        return VilageFcstResponseDto;
+    }
+
+    private VilageFcstResponseDto.Item createItem(String category, String baseDate, String baseTime, String fcstDate, String fcstTime, String value) {
+        VilageFcstResponseDto.Item item = new VilageFcstResponseDto.Item();
+        item.setCategory(category);
+        item.setBaseDate(baseDate);
+        item.setBaseTime(baseTime);
+        item.setFcstDate(fcstDate);
+        item.setFcstTime(fcstTime);
+        item.setFcstValue(value);
+        item.setNx(0);
+        item.setNy(0);
+        return item;
     }
 
 }

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/reader/WeatherReader.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/reader/WeatherReader.java
@@ -16,8 +16,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-//TODO 아직 오류에 대한 예외처리는 하지 않음. -> Job은 예외를 외부로 던지면 안 됨. Job은 수행 중 발생한 오류를 JobRepository에 보고할 의무를 진다.
-//TODO Batch Job 예외 처리 찾아보기
 @Slf4j
 @Component
 @StepScope // job parameters 주입을 위해 빈 생성 시점을 step 생성 시점으로 미룬다.

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -37,6 +37,8 @@ api:
     key: ${MID_RANGE_WEATHER_API_KEY}
   air-quality-service:
     key : ${AIR_QUALITY_KEY}
+  tomorrow:
+    key : ${TOMORROW_API_KEY}
 
 
 ---


### PR DESCRIPTION
## 📌 연관된 이슈

- close #458 

---

## 📝작업 내용

1. 기상청 open api 실패하는 경우가 잦아서 기상청 open api가 실패했을 시 새로운 src를 호출하는 경우가 필요했습니다. 
2. 기존 processor에서 기상청 api를 호출실패했을 시 tomorrow.io 를 호출하는 AlterApiCaller 클래스를 생성했습니다.
3. 기상청 응답 DTO인 VilageFcstResponseDto 형식에 맞추는 convertToVilageFcstResponseDto 메소드를 작성했습니다. 
4. 실제로 DB에 값을 잘 받아오는 것을 확인했습니다. 

현재 흐름은 다음과 같습니다 .

기상청 단기예보 3번 시도 --> 실패시 tomorrow.io 예보 3번 시도 --> 전부 실패시 default 값 반환

---


## 💬리뷰 요구사항

배포할텐데 잘 동작하는지 모니터링 부탁드립니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)