### PR TITLE
fix: 브리핑에서 시작시각과 종료시각이 같은 기상 리스크는 무시하도록 처리

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -164,7 +164,7 @@ public class WeatherService {
         }
 
         final List<WeatherRisk> filteredRisk = allRisks.stream()
-                .filter(r -> r.getEndTime().isAfter(now))
+                .filter(r -> r.getEndTime().isAfter(now) && r.getEndTime().isAfter(r.getStartTime()))
                 .sorted(Briefing.RISK_COMPARATOR) // 우선 순위가 가장 앞서는 것이 맨 앞에 오도록 정렬한다.
                 .toList();
         if (filteredRisk.isEmpty()) { // 기상 특이 사항이 없는 것이니 exception이 아닌 false 응답을 보낸다.


### PR DESCRIPTION
## 📌 연관된 이슈

- close #566 

---

## 📝작업 내용

startTime == endTime 인 기상 리스크는 브리핑 메시지 생성 시 무시하도록 수정하였습니다.

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)