### PR TITLE
[Fix] 기상 리스크가 현재 시각 + 23시각 이후에 시작/종료하는 경우 메시지

### DIFF
--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/WeatherRisk.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/entity/WeatherRisk.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,7 +28,9 @@ public class WeatherRisk {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long weatherRiskId;
+    @Setter
     private LocalDateTime startTime;
+    @Setter
     private LocalDateTime endTime;
     @Column(name = "nx")
     private int nx;

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -157,14 +157,26 @@ public class WeatherService {
         final int ny = farm.getNy();
 
         final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime upperbound = now.plusDays(1).minusHours(1).truncatedTo(ChronoUnit.HOURS);
 
         final List<WeatherRisk> allRisks = weatherRiskRepository.findByNxAndNyWithMaxJobExecutionId(nx, ny);
         if (allRisks.isEmpty()) { // 기상 특이 사항이 없는 것이니 exception이 아닌 false 응답을 보낸다.
             return new GetWeatherBriefingResponse(false, briefing.buildNoRiskWelcomeMsg(now.getHour()), briefing.buildNoRiskWeatherMsg(memberId, now.getHour()));
         }
+        // risk의 시작 시각이 now 전인 경우에는 now를 시작시각으로 사용한다.
+        // risk의 종료 시각을 현재 시각(분 아래는 절삭) + 23시간으로 자른다.
+        allRisks.forEach(x -> {
+            if (x.getStartTime().isBefore(now))
+                x.setStartTime(now);
+            if (x.getEndTime().isAfter(upperbound))
+                x.setEndTime(upperbound);
+        });
 
         final List<WeatherRisk> filteredRisk = allRisks.stream()
-                .filter(r -> r.getEndTime().isAfter(now) && r.getEndTime().isAfter(r.getStartTime()))
+                .filter(r -> {
+                    LocalDateTime start = r.getStartTime();
+                    LocalDateTime end = r.getEndTime();
+                    return (end.isAfter(now) && end.isAfter(start));})
                 .sorted(Briefing.RISK_COMPARATOR) // 우선 순위가 가장 앞서는 것이 맨 앞에 오도록 정렬한다.
                 .toList();
         if (filteredRisk.isEmpty()) { // 기상 특이 사항이 없는 것이니 exception이 아닌 false 응답을 보낸다.

--- a/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/imsnacks/Nyeoreumnagi/weather/service/WeatherService.java
@@ -173,9 +173,9 @@ public class WeatherService {
         });
 
         final List<WeatherRisk> filteredRisk = allRisks.stream()
-                .filter(r -> {
-                    LocalDateTime start = r.getStartTime();
-                    LocalDateTime end = r.getEndTime();
+                .filter(x -> {
+                    LocalDateTime start = x.getStartTime();
+                    LocalDateTime end = x.getEndTime();
                     return (end.isAfter(now) && end.isAfter(start));})
                 .sorted(Briefing.RISK_COMPARATOR) // 우선 순위가 가장 앞서는 것이 맨 앞에 오도록 정렬한다.
                 .toList();


### PR DESCRIPTION
## 📌 연관된 이슈

- close #이슈 번호

---

## 📝작업 내용

브리핑 서비스에서 기상 리스크를 처리할 때,
시작 시각이 현 시각 이전이면 시작 시각을 now(분 이하는 버림)로 바꿈.
종료 시각이 현 시각 + 23시간 이후면 종료 시각을 now(분 이하는 버림)+23시간으로 바꿈.

---

### 스크린샷 (선택)

---

## 💬리뷰 요구사항

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)