### PR TITLE
[Hotfix] 단기예보 batch 1시간 이전 정보 저장하도록 수정

### DIFF
--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
@@ -92,7 +92,12 @@ public class WeatherWriter implements ItemWriter<ShortTermWeatherDto>, StepExecu
 
         log.info("afterStep: shadow 테이블 rename 작업 시작");
 
-        String nowFcstTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH00"));
+        LocalDateTime nowHour = LocalDateTime.now()
+                .withMinute(0)
+                .withSecond(0)
+                .withNano(0);
+        Timestamp nowFcstTime = Timestamp.valueOf(nowHour);
+
         Timestamp now = Timestamp.valueOf(LocalDateTime.now());
 
         String sql = "INSERT INTO short_term_weather_forecast_shadow ( " +

--- a/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
+++ b/batch/src/main/java/com/ImSnacks/NyeoreumnagiBatch/shortTermWeatherForecast/writer/WeatherWriter.java
@@ -17,6 +17,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -88,6 +91,17 @@ public class WeatherWriter implements ItemWriter<ShortTermWeatherDto>, StepExecu
         }
 
         log.info("afterStep: shadow 테이블 rename 작업 시작");
+
+        String nowFcstTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH00"));
+        Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+
+        String sql = "INSERT INTO short_term_weather_forecast_shadow ( " +
+                "fcst_time, nx, ny, humidity, precipitation, sky_status, snow, temperature, update_at, wind_speed, wind_direction " +
+                ") SELECT fcst_time, nx, ny, humidity, precipitation, sky_status, snow, temperature, ?, wind_speed, wind_direction " +
+                "FROM short_term_weather_forecast " +
+                "WHERE fcst_time = ?";
+
+        jdbcTemplate.update(sql, now, nowFcstTime);
 
         try {
             jdbcTemplate.execute("DROP TABLE IF EXISTS short_term_weather_forecast_backup");


### PR DESCRIPTION
## 📝작업 내용

단기예보 batch가 14시 15분에 돌면 14시 정보를 저장하지 않는 문제를 발견했습니다. 

기존 backup 테이블에서 정보를 가져오는 것으로 수정했습니다. 

---

## 💬리뷰 요구사항

없습니다. 

---

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)